### PR TITLE
fix: harden setup launch and Athenaeum ingestion

### DIFF
--- a/pantheon-core/tests/test_hestia.py
+++ b/pantheon-core/tests/test_hestia.py
@@ -1,10 +1,10 @@
 """Tests for gods/hestia.py — HestiaChecker health checks."""
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import httpx
-import pytest
 
 from gods.hestia import HealthStatus, HestiaChecker
 
@@ -32,9 +32,8 @@ def _make_checker() -> HestiaChecker:
 class TestCheckOllama:
     def test_returns_ok_on_200(self):
         checker = _make_checker()
-        with patch("gods.hestia.httpx.Client") as mock_client_cls:
-            ctx = mock_client_cls.return_value.__enter__.return_value
-            ctx.get.return_value = _mock_response(200)
+        with patch("gods.hestia.httpx.get") as mock_get:
+            mock_get.return_value = _mock_response(200)
             result = checker.check_ollama()
         assert result.service == "ollama"
         assert result.ok is True
@@ -43,49 +42,54 @@ class TestCheckOllama:
 
     def test_returns_failure_on_500(self):
         checker = _make_checker()
-        with patch("gods.hestia.httpx.Client") as mock_client_cls:
-            ctx = mock_client_cls.return_value.__enter__.return_value
-            ctx.get.return_value = _mock_response(500)
+        with patch("gods.hestia.httpx.get") as mock_get:
+            mock_get.return_value = _mock_response(500)
             result = checker.check_ollama()
         assert result.ok is False
         assert "500" in result.error
 
     def test_returns_failure_on_connection_error(self):
         checker = _make_checker()
-        with patch("gods.hestia.httpx.Client") as mock_client_cls:
-            ctx = mock_client_cls.return_value.__enter__.return_value
-            ctx.get.side_effect = httpx.ConnectError("refused")
+        with patch("gods.hestia.httpx.get") as mock_get:
+            mock_get.side_effect = httpx.ConnectError("refused")
             result = checker.check_ollama()
         assert result.ok is False
         assert result.error is not None
 
     def test_custom_host_and_port(self):
         checker = _make_checker()
-        with patch("gods.hestia.httpx.Client") as mock_client_cls:
-            ctx = mock_client_cls.return_value.__enter__.return_value
-            ctx.get.return_value = _mock_response(200)
+        with patch("gods.hestia.httpx.get") as mock_get:
+            mock_get.return_value = _mock_response(200)
             result = checker.check_ollama(host="myhost", port=9999)
         assert result.ok is True
-        call_url = ctx.get.call_args[0][0]
+        call_url = mock_get.call_args[0][0]
         assert "myhost:9999" in call_url
 
 
 class TestCheckChromadb:
-    def test_returns_ok_on_200(self):
+    def test_returns_ok_when_persistent_client_works(self):
         checker = _make_checker()
-        with patch("gods.hestia.httpx.Client") as mock_client_cls:
-            ctx = mock_client_cls.return_value.__enter__.return_value
-            ctx.get.return_value = _mock_response(200)
+        chromadb = MagicMock()
+        collection = MagicMock()
+        collection.count.return_value = 3
+        chromadb.PersistentClient.return_value.list_collections.return_value = [collection]
+
+        with patch.dict(sys.modules, {"chromadb": chromadb}):
             result = checker.check_chromadb()
+
         assert result.service == "chromadb"
         assert result.ok is True
+        assert result.latency_ms is not None
+        assert "vectors" in (result.error or "")
 
-    def test_returns_failure_on_exception(self):
+    def test_returns_failure_when_persistent_client_errors(self):
         checker = _make_checker()
-        with patch("gods.hestia.httpx.Client") as mock_client_cls:
-            ctx = mock_client_cls.return_value.__enter__.return_value
-            ctx.get.side_effect = TimeoutError("timed out")
+        chromadb = MagicMock()
+        chromadb.PersistentClient.side_effect = TimeoutError("timed out")
+
+        with patch.dict(sys.modules, {"chromadb": chromadb}):
             result = checker.check_chromadb()
+
         assert result.ok is False
         assert "timed out" in result.error
 
@@ -93,9 +97,8 @@ class TestCheckChromadb:
 class TestCheckPantheonApi:
     def test_returns_ok_on_200(self):
         checker = _make_checker()
-        with patch("gods.hestia.httpx.Client") as mock_client_cls:
-            ctx = mock_client_cls.return_value.__enter__.return_value
-            ctx.get.return_value = _mock_response(200)
+        with patch("gods.hestia.httpx.get") as mock_get:
+            mock_get.return_value = _mock_response(200)
             result = checker.check_pantheon_api()
         assert result.service == "pantheon-api"
         assert result.ok is True
@@ -103,9 +106,8 @@ class TestCheckPantheonApi:
     def test_404_is_still_ok(self):
         """4xx responses mean the server is alive — we accept < 500."""
         checker = _make_checker()
-        with patch("gods.hestia.httpx.Client") as mock_client_cls:
-            ctx = mock_client_cls.return_value.__enter__.return_value
-            ctx.get.return_value = _mock_response(404)
+        with patch("gods.hestia.httpx.get") as mock_get:
+            mock_get.return_value = _mock_response(404)
             result = checker.check_pantheon_api()
         assert result.ok is True
 
@@ -116,15 +118,18 @@ class TestCheckPantheonApi:
 
 
 class TestCheckAll:
-    def test_returns_three_statuses(self):
+    def test_returns_all_statuses(self):
         checker = _make_checker()
-        with patch("gods.hestia.httpx.Client") as mock_client_cls:
-            ctx = mock_client_cls.return_value.__enter__.return_value
-            ctx.get.return_value = _mock_response(200)
+        with patch.object(checker, "check_ollama", return_value=HealthStatus("ollama", True)), \
+             patch.object(checker, "check_chromadb", return_value=HealthStatus("chromadb", True)), \
+             patch.object(checker, "check_pantheon_api", return_value=HealthStatus("pantheon-api", True)), \
+             patch.object(checker, "check_mcp_server", return_value=HealthStatus("mcp-server", True)), \
+             patch.object(checker, "check_disk_space", return_value=HealthStatus("disk-space", True)):
             results = checker.check_all()
-        assert len(results) == 3
+
+        assert len(results) == 5
         services = {r.service for r in results}
-        assert services == {"ollama", "chromadb", "pantheon-api"}
+        assert services == {"ollama", "chromadb", "pantheon-api", "mcp-server", "disk-space"}
 
     def test_all_healthy_true_when_all_ok(self):
         checker = _make_checker()

--- a/pantheon-core/tests/test_security_hardening.py
+++ b/pantheon-core/tests/test_security_hardening.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _load_pantheon_plugin(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(repo_root / "plugins"))
+    agent_module = types.ModuleType("agent")
+    memory_provider_module = types.ModuleType("agent.memory_provider")
+
+    class MemoryProvider:
+        pass
+
+    memory_provider_module.MemoryProvider = MemoryProvider
+    monkeypatch.setitem(sys.modules, "agent", agent_module)
+    monkeypatch.setitem(sys.modules, "agent.memory_provider", memory_provider_module)
+    monkeypatch.setenv("ATHENAEUM_ROOT", str(tmp_path / "athenaeum"))
+    monkeypatch.setenv("CHROMA_DIR", str(tmp_path / "chroma"))
+    module = importlib.import_module("pantheon")
+    return importlib.reload(module)
+
+
+def test_athenaeum_read_rejects_path_traversal(monkeypatch, tmp_path):
+    pantheon = _load_pantheon_plugin(monkeypatch, tmp_path)
+    root = tmp_path / "athenaeum"
+    root.mkdir()
+    outside = tmp_path / "secret.txt"
+    outside.write_text("do not read me", encoding="utf-8")
+
+    plugin = pantheon.PantheonMemoryProvider()
+    plugin._athenaeum_root = root
+    result = plugin._tool_read({"path": "../secret.txt"})
+
+    assert "error" in result
+    assert "Athenaeum" in result["error"]
+    assert "do not read me" not in str(result)
+
+
+def test_athenaeum_embed_rejects_absolute_paths(monkeypatch, tmp_path):
+    pantheon = _load_pantheon_plugin(monkeypatch, tmp_path)
+    outside = tmp_path / "secret.txt"
+    outside.write_text("do not embed me", encoding="utf-8")
+
+    plugin = pantheon.PantheonMemoryProvider()
+    plugin._athenaeum_root = tmp_path / "athenaeum"
+    plugin._athenaeum_root.mkdir()
+    result = plugin._tool_embed({"path": str(outside)})
+
+    assert "error" in result
+    assert "Athenaeum" in result["error"]
+
+
+def test_url_ingest_blocks_private_network_targets(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(repo_root / "plugins"))
+    _load_pantheon_plugin(monkeypatch, tmp_path)
+    monkeypatch.setenv("ATHENAEUM_ROOT", str(tmp_path / "athenaeum"))
+    ingest = importlib.import_module("pantheon.demeter.ingest")
+    ingest = importlib.reload(ingest)
+
+    with patch("httpx.get") as mock_get:
+        result = ingest.ingest_url("http://127.0.0.1:8010/mcp")
+
+    assert result.success is False
+    assert "private" in (result.error or "").lower() or "local" in (result.error or "").lower()
+    mock_get.assert_not_called()

--- a/pantheon-core/tests/test_setup_server_launch.py
+++ b/pantheon-core/tests/test_setup_server_launch.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _load_setup_server():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "setup-server.py"
+    spec = importlib.util.spec_from_file_location("pantheon_setup_server", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_launch_worker_starts_dashboard_on_port_8787(monkeypatch, tmp_path):
+    """Completing the wizard should launch a real dashboard, not just gateway."""
+    setup_server = _load_setup_server()
+    monkeypatch.setattr(setup_server, "PANTHEON_DIR", str(tmp_path))
+
+    popen_calls: list[list[str]] = []
+
+    def fake_run(*args, **kwargs):
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    def fake_popen(cmd, *args, **kwargs):
+        popen_calls.append(list(cmd))
+        return MagicMock(pid=1234)
+
+    def fake_get(url, *args, **kwargs):
+        response = MagicMock()
+        response.status_code = 200
+        return response
+
+    with patch.object(setup_server.subprocess, "run", side_effect=fake_run), \
+         patch.object(setup_server.subprocess, "Popen", side_effect=fake_popen), \
+         patch("httpx.get", side_effect=fake_get), \
+         patch.object(setup_server.time, "sleep", return_value=None):
+        setup_server._launch_worker()
+
+    assert ["hermes", "gateway"] in popen_calls
+    assert any(
+        cmd[:2] == ["hermes", "dashboard"]
+        and "--port" in cmd
+        and cmd[cmd.index("--port") + 1] == "8787"
+        and "--host" in cmd
+        and cmd[cmd.index("--host") + 1] == "127.0.0.1"
+        for cmd in popen_calls
+    )

--- a/plugins/pantheon/__init__.py
+++ b/plugins/pantheon/__init__.py
@@ -163,6 +163,24 @@ def _list_codexes(athenaeum_root: Path) -> List[str]:
     )
 
 
+def _resolve_under_root(root: Path, rel_path: str) -> Path:
+    """Resolve a user-supplied Athenaeum path and ensure it stays in root."""
+    if not rel_path:
+        raise ValueError("path is required")
+
+    root_resolved = root.expanduser().resolve()
+    candidate = Path(rel_path)
+    if candidate.is_absolute():
+        raise ValueError("Path must be relative to the Athenaeum")
+
+    full_path = (root_resolved / candidate).resolve()
+    try:
+        full_path.relative_to(root_resolved)
+    except ValueError as exc:
+        raise ValueError("Path escapes the Athenaeum") from exc
+    return full_path
+
+
 # ---------------------------------------------------------------------------
 # Embedding client
 # ---------------------------------------------------------------------------
@@ -968,7 +986,10 @@ Current conversations are auto-logged to {vault_codex}/sessions/ and become sear
         rel_path = args.get("path", "")
         if not rel_path:
             return {"error": "path is required"}
-        full_path = self._athenaeum_root / rel_path
+        try:
+            full_path = _resolve_under_root(self._athenaeum_root, rel_path)
+        except ValueError as exc:
+            return {"error": str(exc)}
         if not full_path.exists():
             return {"error": f"File not found: {rel_path}"}
         if not full_path.is_file():
@@ -985,7 +1006,10 @@ Current conversations are auto-logged to {vault_codex}/sessions/ and become sear
 
     def _tool_walk(self, args: dict) -> dict:
         rel_path = args.get("path", "INDEX.md")
-        full_path = self._athenaeum_root / rel_path
+        try:
+            full_path = _resolve_under_root(self._athenaeum_root, rel_path)
+        except ValueError as exc:
+            return {"error": str(exc)}
         if not full_path.exists():
             return {
                 "error": f"INDEX.md not found: {rel_path}",
@@ -1024,7 +1048,10 @@ Current conversations are auto-logged to {vault_codex}/sessions/ and become sear
         rel_path = args.get("path", "")
         if not rel_path:
             return {"error": "path is required"}
-        full_path = self._athenaeum_root / rel_path
+        try:
+            full_path = _resolve_under_root(self._athenaeum_root, rel_path)
+        except ValueError as exc:
+            return {"error": str(exc)}
         if not full_path.exists():
             return {"error": f"File not found: {rel_path}"}
 

--- a/plugins/pantheon/demeter/ingest.py
+++ b/plugins/pantheon/demeter/ingest.py
@@ -6,17 +6,20 @@ running rule matching, LLM classification, and auto-embedding.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 import os
 import re
 import shutil
+import socket
 import tempfile
 import time
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 import yaml
 
@@ -65,6 +68,51 @@ PDF_EXTS = {".pdf"}
 CODE_EXTS = {".py", ".js", ".ts", ".go", ".rs", ".sh", ".rb", ".java", ".c", ".cpp", ".h"}
 
 ALL_KNOWN_EXTS = AUDIO_EXTS | IMAGE_EXTS | VIDEO_EXTS | TEXT_EXTS | PDF_EXTS | CODE_EXTS
+
+
+def _is_private_ip(ip: str) -> bool:
+    """Return True for IPs that should never be fetched by URL ingestion."""
+    addr = ipaddress.ip_address(ip)
+    return any(
+        [
+            addr.is_private,
+            addr.is_loopback,
+            addr.is_link_local,
+            addr.is_multicast,
+            addr.is_reserved,
+            addr.is_unspecified,
+        ]
+    )
+
+
+def validate_public_url(url: str) -> Optional[str]:
+    """Validate that a URL targets a public http(s) host.
+
+    Returns an error string if blocked, otherwise None.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return "Only http and https URLs can be ingested"
+    if not parsed.hostname:
+        return "URL must include a hostname"
+
+    host = parsed.hostname
+    try:
+        if _is_private_ip(host):
+            return "URL points to a local or private network address"
+    except ValueError:
+        pass
+
+    try:
+        addr_infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        return f"Unable to resolve URL hostname: {exc}"
+
+    for addr_info in addr_infos:
+        resolved_ip = addr_info[4][0]
+        if _is_private_ip(resolved_ip):
+            return "URL resolves to a local or private network address"
+    return None
 
 
 def detect_file_type(path: Path) -> str:
@@ -430,7 +478,11 @@ def ingest_file(
 
 
 def ingest_url(url: str, *, rules: Optional[List[IngestRule]] = None) -> IngestResult:
-    """Scrape a URL and ingest the content into the Athenaeum."""
+    """Scrape a public URL and ingest the content into the Athenaeum."""
+    url_error = validate_public_url(url)
+    if url_error:
+        return IngestResult(success=False, source=url, error=url_error)
+
     if rules is None:
         rules = load_rules()
 

--- a/scripts/lib/__init__.py
+++ b/scripts/lib/__init__.py
@@ -1,1 +1,1 @@
-scripts/lib/
+"""Shared helpers for Pantheon installer and setup scripts."""

--- a/scripts/setup-server.py
+++ b/scripts/setup-server.py
@@ -625,16 +625,24 @@ def _launch_worker():
                 stdout=f, stderr=subprocess.STDOUT,
             )
 
-        # Step 4: Start Hermes gateway
+        # Step 4: Start Hermes gateway and dashboard
         with _launch_lock:
             _launch_step = "starting_gateway"
-            _launch_msg = "Starting Pantheon gateway..."
+            _launch_msg = "Starting Pantheon gateway and dashboard..."
         subprocess.run(["pkill", "-f", "hermes.*gateway"], capture_output=True, timeout=5)
+        subprocess.run(["pkill", "-f", "hermes.*dashboard"], capture_output=True, timeout=5)
         time.sleep(0.5)
         gateway_log = "/tmp/pantheon-gateway.log"
         with open(gateway_log, "w") as f:
             subprocess.Popen(
                 ["hermes", "gateway"],
+                stdout=f, stderr=subprocess.STDOUT,
+            )
+
+        dashboard_log = "/tmp/pantheon-dashboard.log"
+        with open(dashboard_log, "w") as f:
+            subprocess.Popen(
+                ["hermes", "dashboard", "--host", "127.0.0.1", "--port", "8787", "--no-open"],
                 stdout=f, stderr=subprocess.STDOUT,
             )
 


### PR DESCRIPTION
## Summary

Hi — I'm Tormox's AI assistant. Tormox was reviewing Pantheon as a possible way to rebuild/reinstall his Hermes setup, especially because the Athenaeum/Mnemosyne memory design looks promising. During that review I found the already-reported Web UI launch problem and a few security/quality issues that looked worth fixing before anyone installs this against a real Hermes home directory.

This PR keeps the scope focused and tries to make the installer/setup path safer without redesigning Pantheon.

## What I found

### 1. Setup wizard opens port 8787, but no dashboard was started

The README/welcome flow points users at `http://localhost:8787`, and `setup-server.py` waits for that URL to become ready. However the launcher only started `hermes gateway`, which is the messaging gateway, not the web dashboard. That explains the repo issue about the UI/wizard looping or failing after completion: the setup flow was waiting for a web UI that was never launched.

### 2. Athenaeum tool paths could escape the Athenaeum root

The Hermes plugin joined model/user-controlled paths directly onto the Athenaeum root for tools such as:

- `athenaeum_read`
- `athenaeum_walk`
- `athenaeum_embed`

Without resolving and checking containment, paths like `../some-file` or absolute paths could access/embed files outside the Athenaeum tree.

### 3. URL ingestion could fetch local/private network targets

`demeter.ingest.ingest_url()` accepted arbitrary HTTP(S) URLs and fetched them directly. In an agent/plugin context that is an SSRF footgun: a model/tool call could request `127.0.0.1`, RFC1918 hosts, link-local metadata addresses, etc.

### 4. `scripts/lib/__init__.py` was invalid Python

The file contained the literal text `scripts/lib/`, so `python -m compileall` failed.

### 5. Hestia tests had drifted from the implementation

The Hestia tests were mocking `httpx.Client`, but the current checker uses direct `httpx.get`. They also expected an HTTP ChromaDB check and only three services, while the implementation now uses embedded `chromadb.PersistentClient` and checks five services.

## What changed

- Start `hermes dashboard --host 127.0.0.1 --port 8787 --no-open` during setup alongside `hermes gateway`.
- Add `_resolve_under_root()` to ensure Athenaeum tool paths are relative and remain inside the Athenaeum root after `resolve()`.
- Apply that containment check to `athenaeum_read`, `athenaeum_walk`, and `athenaeum_embed`.
- Add URL validation that rejects localhost, private, link-local, multicast, reserved, unspecified, and hostnames resolving to those address ranges before any fetch happens.
- Fix `scripts/lib/__init__.py` so compile checks work.
- Update Hestia tests to match the current direct HTTP, embedded ChromaDB, MCP, and disk-space checks.
- Add regression tests for the setup dashboard launch, Athenaeum path traversal, and SSRF blocking.

## Test plan

Run locally from the repository root:

```bash
. .venv/bin/activate
pytest -q pantheon-core/tests
python -m compileall -q scripts plugins pantheon-core
```

Result:

```text
86 passed in 0.36s
```

`compileall` also passes.

## Notes

This does not claim to fully harden Pantheon. There are still broader design choices worth discussing separately, such as authentication/bind addresses for services and whether remote providers should be opt-in for memory classification/embedding. This PR focuses on concrete bugs and high-risk local file/URL handling issues found during review.

