### PR TITLE
fix: replace deprecated datetime.utcnow() with timezone-aware alternative

### DIFF
--- a/scripts/clawforge-issue-client-token.py
+++ b/scripts/clawforge-issue-client-token.py
@@ -102,7 +102,7 @@ def write_config(conf_path, conf_text, new_auth_text):
 
 
 def backup_config(conf_path):
-    ts = dt.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    ts = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     bak = conf_path.with_suffix(conf_path.suffix + ".bak-pre-clawforge-rotate-" + ts)
     shutil.copy2(conf_path, bak)
     return bak
@@ -163,12 +163,12 @@ def test_connection(instance_id, token, timeout=5.0):
 def write_tokens_file(instance_id, token, dest_dir=None):
     if dest_dir is None:
         dest_dir = Path("/tmp")
-    ts = dt.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    ts = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     fname = "clawforge-tokens-" + instance_id + "-" + ts + ".env"
     out = dest_dir / fname
     body = (
         "# Clawforge client tokens for instance '" + instance_id + "'\n"
-        "# Issued: " + dt.datetime.utcnow().isoformat() + "Z\n"
+        "# Issued: " + dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z") + "\n"
         "# Host:   " + socket.gethostname() + "\n"
         "# DO NOT COMMIT. Mode 0600. Deliver over a secure channel.\n"
         + cfg.env_var + "=" + token + "\n"

--- a/webui/api/routes.py
+++ b/webui/api/routes.py
@@ -6456,8 +6456,8 @@ def handle_post(handler, parsed) -> bool:
         _entry = _dl_counts.get(god_name, {"downloads": 0})
         _entry["downloads"] = _entry.get("downloads", 0) + 1
         if "first_summoned" not in _entry:
-            from datetime import datetime as _dt
-            _entry["first_summoned"] = _dt.utcnow().isoformat() + "Z"
+            from datetime import datetime as _dt, timezone
+            _entry["first_summoned"] = _dt.now(timezone.utc).isoformat().replace("+00:00", "Z")
         _dl_counts[god_name] = _entry
         os.makedirs(os.path.dirname(_dl_path), exist_ok=True)
         with open(_dl_path, "w") as _f:


### PR DESCRIPTION
Closes #17

Replaced all `datetime.utcnow()` calls with `datetime.now(timezone.utc)` to fix `DeprecationWarning` on Python 3.12+.

### Changes
- `webui/api/routes.py:6460` — replaced inline `utcnow()` import + call
- `scripts/clawforge-issue-client-token.py:105,166,171` — replaced 3 `utcnow()` calls

The output format is preserved: `+00:00` is replaced with `Z` where applicable.