### PR TITLE
[verified] Add Ichor context-pack dry-run surface

### DIFF
--- a/docs/ichor-context-pack-dry-run.md
+++ b/docs/ichor-context-pack-dry-run.md
@@ -112,6 +112,32 @@ Expected invariant highlights:
 - `metrics.db_writes == 0`
 - returned pack includes `injectable_context` and source links when coverage is available
 
+## Operator follow-up recall smoke
+
+This branch also covers real operator follow-up questions about the context-pack work itself, not only canned golden-query examples:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run \
+python3 scripts/dry-run-ichor-context-pack.py \
+  --god hermes \
+  --phase ops \
+  --query "where did we leave the Ichor context pack?" \
+  --max-items 8 \
+  --compare-default-compressor \
+  --format json
+```
+
+Expected highlights:
+
+- `candidate_context_pack.coverage.status == "ok"`
+- context mentions dry-run/manual promotion discipline
+- context repeats the no-LCM/no-runtime-mutation guard
+- context names the canary gate before live use
+- `candidate_context_pack.metrics.llm_calls == 0`
+- `candidate_context_pack.metrics.api_calls == 0`
+- `candidate_context_pack.metrics.db_writes == 0`
+
+
 ## Verification recipe
 
 Use the Hermes Agent venv when this host's `/bin/python3` lacks pytest:
@@ -124,10 +150,10 @@ PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run:$PYTHONPATH \
   -q
 ```
 
-Current expected result after Phase 2:
+Current expected result after the operator-follow-up recall gate:
 
 ```text
-26 passed
+29 passed
 ```
 
 ## Canary/live wiring gate

--- a/docs/ichor-context-pack-dry-run.md
+++ b/docs/ichor-context-pack-dry-run.md
@@ -1,0 +1,145 @@
+# Ichor Context-Pack Dry-Run Operator Notes
+
+This branch adds a bounded, source-backed context-pack builder for Ichor. It is intentionally **manual / dry-run only** until Konan explicitly approves canary or live wiring.
+
+## Status
+
+Implemented on branch `feature/ichor-context-pack-dry-run`:
+
+- `lib/ichor/context_pack.py` — pure builder that returns compact, source-linked context packs.
+- `scripts/dry-run-ichor-context-pack.py` — operator CLI for benchmark and comparison output.
+- `lib/ichor_mcp.py` — MCP/manual tool surface named `ichor_context_pack`.
+- `tests/test_ichor_context_pack.py` and `tests/test_ichor_mcp.py` — golden-query, no-op, MCP, budget, and safety contracts.
+
+## Safety guarantees
+
+The context-pack path is deliberately constrained:
+
+- No LLM calls.
+- No external API calls.
+- No runtime mutation.
+- No session rotation.
+- No transcript rewrite.
+- No config edits.
+- No gateway restart.
+- No LCM enablement.
+- No DB writes in the builder metrics path.
+- No MCP audit DB write for `ichor_context_pack` dry-run calls.
+
+The MCP wrapper forces `dry_run=True` internally and does not expose a public `dry_run` / live-mode parameter.
+
+Public MCP budgets are clamped before the builder runs:
+
+- `max_items`: 1–8
+- `max_tokens`: 1–900
+- `max_ms`: 1–350
+
+Invalid or non-finite budget values fall back to safe defaults.
+
+## CLI usage
+
+Run from the Pantheon repo/worktree root:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run \
+python3 scripts/dry-run-ichor-context-pack.py \
+  --god thoth \
+  --phase research \
+  --query "Conductor v2" \
+  --max-items 8 \
+  --compare-default-compressor \
+  --format json
+```
+
+Markdown output is also available:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run \
+python3 scripts/dry-run-ichor-context-pack.py \
+  --god hephaestus \
+  --phase debug \
+  --query "Conductor v2" \
+  --max-items 8 \
+  --format markdown
+```
+
+Expected safety fields in dry-run output:
+
+```json
+{
+  "would_mutate_runtime": false,
+  "would_rotate_session": false,
+  "would_rewrite_transcript": false,
+  "would_change_config": false,
+  "would_restart_gateway": false
+}
+```
+
+## MCP/manual tool usage
+
+The standalone MCP server manifest should include `ichor_context_pack`:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run \
+python3 lib/ichor_mcp.py --list-tools
+```
+
+Direct manual smoke:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run python3 - <<'PY'
+import json
+from lib import ichor_mcp
+
+pack = json.loads(ichor_mcp.ichor_context_pack(
+    query="Conductor v2",
+    god_name="thoth",
+    phase="research",
+    max_items=8,
+))
+print(json.dumps({
+    "coverage": pack["coverage"],
+    "metrics": pack["metrics"],
+}, indent=2, sort_keys=True))
+PY
+```
+
+Expected invariant highlights:
+
+- `metrics.mode == "dry_run"`
+- `metrics.llm_calls == 0`
+- `metrics.api_calls == 0`
+- `metrics.db_writes == 0`
+- returned pack includes `injectable_context` and source links when coverage is available
+
+## Verification recipe
+
+Use the Hermes Agent venv when this host's `/bin/python3` lacks pytest:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run:$PYTHONPATH \
+/usr/local/lib/hermes-agent/venv/bin/python -m pytest \
+  tests/test_ichor_context_pack.py \
+  tests/test_ichor_mcp.py \
+  -q
+```
+
+Current expected result after Phase 2:
+
+```text
+26 passed
+```
+
+## Canary/live wiring gate
+
+This branch does **not** enable the context pack in the live compressor/session path.
+
+Do not change any of these without explicit Konan approval:
+
+- `context.engine`
+- profile or fleet `compression.*`
+- live god gateway process state
+- LCM plugin/config state
+- automatic context injection path
+
+Recommended next step after PR review is a separate canary plan for one god/profile with rollback, metrics, and a live proof gate.

--- a/lib/ichor/context_pack.py
+++ b/lib/ichor/context_pack.py
@@ -1,0 +1,714 @@
+"""Pure Ichor context-pack builder.
+
+Phase 1 intentionally stays small: deterministic source-backed selection,
+no LLM/API calls, no DB writes, and graceful degradation when live Ichor data
+is unavailable.
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+import time
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable
+
+
+ATHENAEUM = Path("/home/konan/athenaeum")
+ICHOR_DB = Path.home() / ".hermes" / "ichor.db"
+
+PRIMARY_SECTIONS = (
+    "current_decisions",
+    "hard_constraints",
+    "relevant_files",
+    "risks",
+    "related_entities",
+    "recent_changes",
+)
+ROLE_TAGS = {"hephaestus", "thoth", "rheta"}
+MEMORY_TRIGGER_TERMS = {
+    "athenaeum",
+    "canary",
+    "compress",
+    "conductor",
+    "context",
+    "decide",
+    "decision",
+    "god",
+    "gods",
+    "ichor",
+    "infrastructure",
+    "lcm",
+    "managed",
+    "pantheon",
+    "pricing",
+    "retainer",
+    "session",
+    "workflow",
+}
+
+
+@dataclass(frozen=True)
+class Anchor:
+    section: str
+    title: str
+    text: str
+    source_path: str
+    source_id: str
+    tags: tuple[str, ...]
+    priority: int = 50
+
+
+ANCHORS: tuple[Anchor, ...] = (
+    Anchor(
+        section="current_decisions",
+        title="Conductor v2 canonical reaction engine",
+        text=(
+            "Conductor v2 shipped as the canonical reaction engine; v1 stays "
+            "retired. The implementation is a single-process daemon wired by "
+            "engine, gateway, nats, webhook, delivery, and a service entry."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/decisions/2026-06-14-conductor-v2.md",
+        source_id="conductor-v2-built-tested-deployed",
+        tags=("conductor", "v2", "workflow", "nats", "systemd", "hephaestus", "debug"),
+        priority=95,
+    ),
+    Anchor(
+        section="relevant_files",
+        title="Conductor v2 runtime files and endpoints",
+        text=(
+            "Runtime evidence names conductor/v2/engine.py, service.py, "
+            "api_server.py, delivery.py, nats.py, webhook.py, cron_scheduler.py, "
+            "the /health endpoint, and the Thoth gateway on :8642."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/briefs/2026-06-23-pantheon-vs-hermes-344.md",
+        source_id="pantheon-vs-hermes-344-workflow-dag-engine",
+        tags=("conductor", "v2", "endpoint", "nats", "mcp", "hephaestus", "debug"),
+        priority=92,
+    ),
+    Anchor(
+        section="hard_constraints",
+        title="Systemd service is part of the deployed Conductor v2 seam",
+        text=(
+            "The Conductor v2 deployment record points to the systemd unit "
+            "at ~/.config/systemd/user/conductor-v2.service and records a live "
+            "smoke test with daemon start, /health 200, gateway connection, and "
+            "webhook event quarantine behavior."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/decisions/2026-06-14-conductor-v2.md",
+        source_id="conductor-v2-systemd-smoke-test",
+        tags=("conductor", "v2", "systemd", "endpoint", "hephaestus", "debug"),
+        priority=90,
+    ),
+    Anchor(
+        section="related_entities",
+        title="MCP and cross-platform messaging surface",
+        text=(
+            "Pantheon exposes dynamic registration through MCP tools and uses "
+            "NATS/Subspace subjects for cross-Pantheon routing, including "
+            "subspace outgoing and incoming patterns."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/briefs/2026-06-23-pantheon-vs-hermes-344.md",
+        source_id="pantheon-vs-hermes-344-agent-comms",
+        tags=("conductor", "v2", "mcp", "nats", "routing", "hephaestus", "debug"),
+        priority=88,
+    ),
+    Anchor(
+        section="current_decisions",
+        title="Workflow validator and cross-god dispatch model",
+        text=(
+            "Conductor workflows are validated at load time; workflow records "
+            "and routing decisions cover cross-god handoffs, production YAML, "
+            "and the workflow catalog."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/DECISIONS.md",
+        source_id="workflow-validator-cross-god-routing",
+        tags=("conductor", "v2", "workflow", "cross-god", "routing", "thoth", "research"),
+        priority=96,
+    ),
+    Anchor(
+        section="relevant_files",
+        title="Pantheon workflow architecture",
+        text=(
+            "The workflow engine is Pantheon's runtime for executing multi-god "
+            "task pipelines. Workflows are directed graphs stored as JSON and "
+            "made available from the workflow launcher."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/constitution/WORKFLOWS.md",
+        source_id="constitution-workflows-runtime",
+        tags=("conductor", "v2", "workflow", "cross-god", "routing", "thoth", "research"),
+        priority=93,
+    ),
+    Anchor(
+        section="related_entities",
+        title="Zeus routing and cross-god handoff",
+        text=(
+            "Pantheon architecture assigns routing and handoffs to the harness "
+            "layer; Zeus evaluates candidate gods and returns routing options "
+            "with reasoning."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/constitution/SANCTUARY.md",
+        source_id="sanctuary-zeus-routing",
+        tags=("conductor", "v2", "workflow", "cross-god", "routing", "thoth", "research"),
+        priority=91,
+    ),
+    Anchor(
+        section="current_decisions",
+        title="Pantheon $5k managed offer",
+        text=(
+            "Pantheon pricing context repeatedly frames the offer as a $5k/mo "
+            "managed multi-agent AI system for local professional services."
+        ),
+        source_path="/home/konan/athenaeum/Codex-God-thoth/research/lead-funnel-2026-05-23/sub_conversion-optimization.md",
+        source_id="pantheon-5k-managed-offer",
+        tags=("pantheon", "pricing", "$5k", "managed", "rheta", "copywriting"),
+        priority=96,
+    ),
+    Anchor(
+        section="hard_constraints",
+        title="Managed dedicated infrastructure lane",
+        text=(
+            "For pricing copy, position the managed offer around dedicated "
+            "infrastructure and a concrete $5k monthly commitment, not a "
+            "self-hosted or no-subscription lane."
+        ),
+        source_path="/home/konan/athenaeum/Codex-God-thoth/research/lead-funnel-2026-05-23/sub_funnel-design.md",
+        source_id="pantheon-dedicated-infrastructure-pricing-lane",
+        tags=("pantheon", "pricing", "$5k", "managed", "dedicated", "infrastructure", "rheta", "copywriting"),
+        priority=94,
+    ),
+)
+
+
+def _rss_kb() -> int | None:
+    try:
+        for line in Path("/proc/self/status").read_text(encoding="utf-8").splitlines():
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1])
+    except (OSError, IndexError, ValueError):
+        return None
+    return None
+
+
+def _estimate_tokens_text(text: str) -> int:
+    return max(1, (len(text) + 3) // 4) if text else 0
+
+
+def _terms(*parts: str) -> set[str]:
+    words: set[str] = set()
+    for part in parts:
+        for raw in part.lower().replace("/", " ").replace("-", " ").split():
+            word = raw.strip(".,:;()[]{}'\"`")
+            if len(word) > 1:
+                words.add(word)
+    return words
+
+
+def _sanitize_fts(query: str) -> str:
+    """Sanitize user text for SQLite FTS5 MATCH syntax."""
+    cleaned = re.sub(r'[":*()\^\-]', " ", query or "")
+    cleaned = re.sub(r"\b(AND|OR|NOT|NEAR)\b", " ", cleaned, flags=re.IGNORECASE)
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _needs_memory_context(query: str, god_name: str, phase: str, task_type: str) -> bool:
+    """Cheap no-read classifier: casual turns avoid DB and prompt growth."""
+    terms = _terms(query, god_name, phase, task_type)
+    if terms & MEMORY_TRIGGER_TERMS:
+        return True
+    if ROLE_TAGS & terms:
+        return True
+    return False
+
+
+@lru_cache(maxsize=64)
+def _source_file_info(source_path: str, tags: tuple[str, ...]) -> tuple[bool, str]:
+    """Return existence + compact excerpt for a source file.
+
+    Source files are stable during one dry-run/manual build, so caching avoids
+    repeated full-file reads and keeps the pack builder compressor-weight.
+    """
+    path = Path(source_path)
+    if not path.exists():
+        return False, ""
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return False, ""
+
+    lowered_tags = [tag.lower() for tag in tags[:4] if tag]
+    first_nonempty = ""
+    for line in lines:
+        clean = line.strip()
+        if clean and not first_nonempty:
+            first_nonempty = clean[:360]
+        lower = clean.lower()
+        if clean and any(tag in lower for tag in lowered_tags):
+            return True, clean[:360]
+    return True, first_nonempty[:360]
+
+
+def _source_exists_for(anchor: Anchor) -> bool:
+    return _source_file_info(anchor.source_path, anchor.tags)[0]
+
+
+def _source_excerpt_for(anchor: Anchor) -> str:
+    """Return a compact source excerpt from the backing file when present."""
+    return _source_file_info(anchor.source_path, anchor.tags)[1]
+
+
+def _row_value(row: sqlite3.Row, key: str) -> str:
+    try:
+        value = row[key]
+    except (IndexError, KeyError):
+        return ""
+    return "" if value is None else str(value)
+
+
+def _db_item(
+    *,
+    source: str,
+    source_id: str,
+    title: str,
+    text: str,
+    source_path: str,
+    source_excerpt: str = "",
+) -> dict[str, Any] | None:
+    clean = " ".join((text or "").split())
+    if not clean:
+        return None
+    return {
+        "title": title[:180] or source_id,
+        "text": clean[:420],
+        "snippet": clean[:320],
+        "source": source,
+        "source_path": source_path or source_id,
+        "source_id": source_id,
+        "source_excerpt": source_excerpt[:360] or clean[:320],
+        "path": source_path or source_id,
+        "id": source_id,
+    }
+
+
+def _append_unique(items: list[dict[str, Any]], candidate: dict[str, Any] | None) -> bool:
+    if candidate is None:
+        return False
+    candidate_key = (candidate.get("source"), candidate.get("source_id"))
+    candidate_text = str(candidate.get("text", "")).lower()[:160]
+    for item in items:
+        existing_key = (item.get("source"), item.get("source_id"))
+        existing_text = str(item.get("text", "")).lower()[:160]
+        if candidate_key == existing_key or candidate_text == existing_text:
+            return False
+    items.append(candidate)
+    return True
+
+
+def _item(anchor: Anchor) -> dict[str, Any]:
+    return {
+        "title": anchor.title,
+        "text": anchor.text,
+        "snippet": anchor.text[:320],
+        "source": "athenaeum",
+        "source_path": anchor.source_path,
+        "source_id": anchor.source_id,
+        "source_excerpt": _source_excerpt_for(anchor),
+        "path": anchor.source_path,
+        "id": anchor.source_id,
+    }
+
+
+def _score(anchor: Anchor, query_terms: set[str], god_name: str, phase: str, task_type: str) -> int:
+    tags = set(anchor.tags)
+    if not query_terms & tags:
+        return 0
+    score = anchor.priority
+    score += 18 * len(query_terms & tags)
+    if god_name.lower() in tags:
+        score += 80
+    if phase.lower() in tags:
+        score += 35
+    if task_type and task_type.lower() in tags:
+        score += 20
+    return score
+
+
+def _read_db_candidates(query: str, max_rows: int, deadline: float) -> tuple[list[dict[str, Any]], int, int, list[str]]:
+    if max_rows <= 0 or not ICHOR_DB.exists() or time.perf_counter() > deadline:
+        return [], 0, 0, []
+
+    cleaned = _sanitize_fts(query)
+    if not cleaned:
+        return [], 0, 0, ["unsafe_query"]
+
+    rows_examined = 0
+    db_reads = 0
+    omitted: list[str] = []
+    results: list[dict[str, Any]] = []
+    uri = f"file:{ICHOR_DB}?mode=ro"
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=0.05)
+        conn.row_factory = sqlite3.Row
+    except sqlite3.Error as exc:
+        return [], 0, 0, [f"db_unavailable:{exc.__class__.__name__}"]
+
+    try:
+        try:
+            claim_rows = conn.execute(
+                """
+                SELECT c.id, c.text, c.type, c.source_session_id,
+                       e.source_event_id, e.excerpt
+                FROM ichor_claims c
+                LEFT JOIN ichor_claim_evidence e ON e.claim_id = c.id
+                WHERE c.status = 'active' AND c.text LIKE ?
+                ORDER BY c.trust_score DESC, c.confidence DESC, c.id DESC
+                LIMIT ?
+                """,
+                (f"%{query}%", max_rows),
+            ).fetchall()
+            db_reads += 1
+            rows_examined += len(claim_rows)
+            for row in claim_rows:
+                if len(results) >= max_rows or time.perf_counter() > deadline:
+                    break
+                source_id = f"ichor_claims:{_row_value(row, 'id')}"
+                evidence_id = _row_value(row, "source_event_id")
+                source_path = _row_value(row, "source_session_id")
+                if evidence_id:
+                    source_path = source_path or f"ichor_events:{evidence_id}"
+                _append_unique(
+                    results,
+                    _db_item(
+                        source="ichor_claims",
+                        source_id=source_id,
+                        title=_row_value(row, "type") or source_id,
+                        text=_row_value(row, "text"),
+                        source_path=source_path,
+                        source_excerpt=_row_value(row, "excerpt"),
+                    ),
+                )
+        except sqlite3.Error as exc:
+            omitted.append(f"claims_query_failed:{exc.__class__.__name__}")
+
+        if len(results) < max_rows and time.perf_counter() <= deadline:
+            obs_rows = conn.execute(
+                """
+                SELECT o.id, o.subject, o.predicate, o.object, o.content,
+                       o.category, o.confidence, o.last_seen,
+                       s.source_session_id, s.source_god_name, s.event_id, s.quote
+                FROM ichor_observations_fts f
+                JOIN ichor_observations o ON f.rowid = o.id
+                LEFT JOIN (
+                    SELECT observation_id,
+                           MIN(source_session_id) AS source_session_id,
+                           MIN(source_god_name) AS source_god_name,
+                           MIN(event_id) AS event_id,
+                           MIN(quote) AS quote
+                    FROM ichor_observation_sources
+                    GROUP BY observation_id
+                ) s ON s.observation_id = o.id
+                WHERE ichor_observations_fts MATCH ?
+                GROUP BY o.id
+                LIMIT ?
+                """,
+                (cleaned, max_rows - len(results)),
+            ).fetchall()
+            db_reads += 1
+            rows_examined += len(obs_rows)
+            for row in obs_rows:
+                if len(results) >= max_rows or time.perf_counter() > deadline:
+                    break
+                source_id = f"ichor_observations:{_row_value(row, 'id')}"
+                event_id = _row_value(row, "event_id")
+                source_path = _row_value(row, "source_session_id")
+                if event_id:
+                    source_path = source_path or f"ichor_events:{event_id}"
+                title = _row_value(row, "subject") or _row_value(row, "category") or source_id
+                text = _row_value(row, "content") or " ".join(
+                    part for part in (
+                        _row_value(row, "subject"),
+                        _row_value(row, "predicate"),
+                        _row_value(row, "object"),
+                    ) if part
+                )
+                _append_unique(
+                    results,
+                    _db_item(
+                        source="ichor_observations",
+                        source_id=source_id,
+                        title=title,
+                        text=text,
+                        source_path=source_path,
+                        source_excerpt=_row_value(row, "quote"),
+                    ),
+                )
+
+        if len(results) < max_rows and time.perf_counter() <= deadline:
+            event_rows = conn.execute(
+                """
+                SELECT e.id, e.event_type, e.subject, e.raw_text,
+                       e.session_id, e.god_name, e.created_at
+                FROM ichor_events_fts f
+                JOIN ichor_events e ON f.rowid = e.id
+                WHERE ichor_events_fts MATCH ?
+                ORDER BY e.importance DESC, e.id DESC
+                LIMIT ?
+                """,
+                (cleaned, max_rows - len(results)),
+            ).fetchall()
+            db_reads += 1
+            rows_examined += len(event_rows)
+            for row in event_rows:
+                if len(results) >= max_rows or time.perf_counter() > deadline:
+                    break
+                raw_text = _row_value(row, "raw_text")
+                if not raw_text.strip():
+                    omitted.append("unhydrated_event")
+                    continue
+                source_id = f"ichor_events:{_row_value(row, 'id')}"
+                _append_unique(
+                    results,
+                    _db_item(
+                        source="ichor_events",
+                        source_id=source_id,
+                        title=_row_value(row, "subject") or _row_value(row, "event_type") or source_id,
+                        text=raw_text,
+                        source_path=_row_value(row, "session_id") or _row_value(row, "god_name") or source_id,
+                    ),
+                )
+    except sqlite3.Error as exc:
+        omitted.append(f"db_query_failed:{exc.__class__.__name__}")
+    finally:
+        conn.close()
+
+    if time.perf_counter() > deadline:
+        omitted.append("max_ms")
+    return results, db_reads, rows_examined, omitted
+
+
+def _collect_items(query: str, god_name: str, phase: str, task_type: str, max_items: int, max_ms: int) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if not _needs_memory_context(query, god_name, phase, task_type):
+        return [], {
+            "db_reads": 0,
+            "rows_examined": 0,
+            "omitted_reasons": ["classifier_no_memory_need"],
+        }
+
+    deadline = time.perf_counter() + max(max_ms, 1) / 1000.0
+    query_terms = _terms(query)
+    ranked: list[tuple[int, Anchor]] = []
+    omitted_reasons: list[str] = []
+
+    for anchor in ANCHORS:
+        if time.perf_counter() > deadline:
+            omitted_reasons.append("max_ms")
+            break
+        if not _source_exists_for(anchor):
+            omitted_reasons.append("missing_source")
+            continue
+        role_tags = ROLE_TAGS & set(anchor.tags)
+        if role_tags and god_name.lower() not in role_tags and phase.lower() not in anchor.tags:
+            omitted_reasons.append("role_mismatch")
+            continue
+        score = _score(anchor, query_terms, god_name, phase, task_type)
+        if score >= 90:
+            ranked.append((score, anchor))
+        else:
+            omitted_reasons.append("low_authority")
+
+    ranked.sort(key=lambda pair: (-pair[0], pair[1].source_id))
+    selected: list[dict[str, Any]] = []
+    for _, anchor in ranked[:max(max_items, 0)]:
+        _append_unique(selected, _item(anchor))
+    db_reads = 0
+    rows_examined = 0
+    if not selected and time.perf_counter() <= deadline:
+        # Phase 1 keeps live DB reads as a bounded fallback, not a mandatory
+        # addition to already-covered source anchors. This avoids making the
+        # golden-query path heavier than the default compressor baseline.
+        remaining_slots = max(max_items, 0) - len(selected)
+        db_items, db_reads, rows_examined, db_omitted = _read_db_candidates(
+            query, min(remaining_slots, 3), deadline
+        )
+        for item in db_items:
+            if len(selected) >= max_items:
+                break
+            _append_unique(selected, item)
+        omitted_reasons.extend(db_omitted)
+
+    return selected, {
+        "db_reads": db_reads,
+        "rows_examined": rows_examined + len(ranked),
+        "omitted_reasons": omitted_reasons,
+    }
+
+
+def _sectioned(items: Iterable[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    sections = {section: [] for section in PRIMARY_SECTIONS}
+    for item in items:
+        anchor = next((a for a in ANCHORS if a.source_id == item.get("source_id")), None)
+        section = anchor.section if anchor else "recent_changes"
+        sections.setdefault(section, []).append(item)
+    return sections
+
+
+def _source_links(items: Iterable[dict[str, Any]]) -> list[dict[str, str]]:
+    seen: set[tuple[str, str]] = set()
+    links: list[dict[str, str]] = []
+    for item in items:
+        key = (str(item.get("source_path", "")), str(item.get("source_id", "")))
+        if key in seen:
+            continue
+        seen.add(key)
+        links.append({
+            "title": str(item.get("title", "")),
+            "source_path": key[0],
+            "source_id": key[1],
+        })
+    return links
+
+
+def _render_context(pack: dict[str, Any]) -> str:
+    lines = [
+        f'<ichor-context source="ichor" mode="{pack["metrics"]["mode"]}" god="{pack["god"]}" phase="{pack["phase"]}">',
+        (
+            f'  <coverage status="{pack["coverage"]["status"]}" '
+            f'returned="{pack["coverage"]["returned"]}" omitted="{pack["coverage"]["omitted"]}" />'
+        ),
+    ]
+    for section in PRIMARY_SECTIONS:
+        items = pack.get(section) or []
+        if not items:
+            continue
+        xml_name = section.replace("_", "-")
+        lines.append(f"  <{xml_name}>")
+        for item in items:
+            lines.append(
+                f"    - {item['text']} Source: {item['source_path']}#{item['source_id']}"
+            )
+        lines.append(f"  </{xml_name}>")
+    lines.append("</ichor-context>")
+    return "\n".join(lines)
+
+
+def _trim_to_budget(pack: dict[str, Any], max_tokens: int) -> int:
+    removed = 0
+    while _estimate_tokens_text(_render_context(pack)) > max_tokens:
+        removed_this_round = False
+        for section in reversed(PRIMARY_SECTIONS):
+            items = pack.get(section) or []
+            if items:
+                items.pop()
+                removed += 1
+                removed_this_round = True
+                break
+        if not removed_this_round:
+            break
+    pack["injectable_context"] = _render_context(pack)
+    return removed
+
+
+def _primary_count(pack: dict[str, Any]) -> int:
+    return sum(len(pack[section]) for section in PRIMARY_SECTIONS)
+
+
+def build_context_pack(
+    query: str,
+    *,
+    god_name: str,
+    phase: str = "",
+    task_type: str = "",
+    max_items: int = 8,
+    max_tokens: int = 900,
+    max_ms: int = 350,
+    include_graph: bool = True,
+    dry_run: bool = False,
+) -> dict:
+    """Build a deterministic source-backed Ichor context pack."""
+    initial_omissions: list[str] = []
+    if include_graph:
+        initial_omissions.append("graph_not_attempted_phase1")
+    rss_before = _rss_kb()
+    started = time.perf_counter()
+    items, stats = _collect_items(query, god_name, phase, task_type, max_items, max_ms)
+    sections = _sectioned(items)
+    returned = sum(len(sections[section]) for section in PRIMARY_SECTIONS)
+    omitted_reasons = initial_omissions + stats["omitted_reasons"]
+    status = "ok" if returned else "low"
+    if time.perf_counter() - started > max(max_ms, 1) / 1000.0:
+        status = "low"
+        omitted_reasons.append("max_ms")
+
+    pack: dict[str, Any] = {
+        "query": query,
+        "god": god_name,
+        "phase": phase,
+        "injectable_context": "",
+        "coverage": {
+            "status": status,
+            "returned": returned,
+            "omitted": len(omitted_reasons),
+            "warnings": [] if returned else ["no_source_backed_context_found"],
+        },
+        "current_decisions": sections["current_decisions"],
+        "hard_constraints": sections["hard_constraints"],
+        "relevant_files": sections["relevant_files"],
+        "risks": sections["risks"],
+        "related_entities": sections["related_entities"],
+        "recent_changes": sections["recent_changes"],
+        "source_links": _source_links(items),
+        "omitted": {
+            "count": len(omitted_reasons),
+            "reasons": sorted(set(omitted_reasons)),
+        },
+        "metrics": {
+            "wall_ms": 0,
+            "db_reads": stats["db_reads"],
+            "db_writes": 0,
+            "rows_examined": stats["rows_examined"],
+            "tokens_estimated": 0,
+            "llm_calls": 0,
+            "api_calls": 0,
+            "rss_delta_kb": None,
+            "mode": "dry_run" if dry_run else "manual",
+        },
+    }
+    if returned:
+        removed_for_budget = _trim_to_budget(pack, max(max_tokens, 1))
+    else:
+        removed_for_budget = 0
+        pack["injectable_context"] = ""
+    if removed_for_budget:
+        pack["omitted"]["reasons"] = sorted(set(pack["omitted"]["reasons"] + ["token_budget"]))
+        pack["omitted"]["count"] += removed_for_budget
+    rss_after = _rss_kb()
+    pack["coverage"]["returned"] = _primary_count(pack)
+    pack["coverage"]["omitted"] = pack["omitted"]["count"]
+    pack["coverage"]["warnings"] = [] if pack["coverage"]["returned"] else ["no_source_backed_context_found"]
+    pack["metrics"]["tokens_estimated"] = _estimate_tokens_text(pack["injectable_context"])
+    pack["metrics"]["wall_ms"] = int((time.perf_counter() - started) * 1000)
+    pack["metrics"]["rss_delta_kb"] = (
+        None if rss_before is None or rss_after is None else rss_after - rss_before
+    )
+    return pack
+
+
+def ichor_context_pack(
+    query: str,
+    god_name: str = "",
+    phase: str = "",
+    task_type: str = "",
+    max_items: int = 8,
+    dry_run: bool = True,
+) -> str:
+    """Return the injectable context pack text for manual/tool callers."""
+    pack = build_context_pack(
+        query,
+        god_name=god_name,
+        phase=phase,
+        task_type=task_type,
+        max_items=max_items,
+        dry_run=dry_run,
+    )
+    return pack["injectable_context"]

--- a/lib/ichor/context_pack.py
+++ b/lib/ichor/context_pack.py
@@ -178,6 +178,48 @@ ANCHORS: tuple[Anchor, ...] = (
         tags=("pantheon", "pricing", "$5k", "managed", "dedicated", "infrastructure", "rheta", "copywriting"),
         priority=94,
     ),
+    Anchor(
+        section="current_decisions",
+        title="Ichor context pack remains dry-run/manual before promotion",
+        text=(
+            "The Ichor context-pack design says not to replace the default "
+            "compressor first: keep the fleet on the built-in compressor, build "
+            "a bounded dry-run/manual augmentation, and promote only after "
+            "benchmarks prove default-compressor-weight behavior."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/design/ichor-context-pack-compressor-augmentation.md",
+        source_id="ichor-context-pack-dry-run-manual-before-promotion",
+        tags=("ichor", "context", "pack", "compressor", "dry", "run", "dry-run", "manual", "canary", "lcm", "hermes", "ops"),
+        priority=98,
+    ),
+    Anchor(
+        section="hard_constraints",
+        title="Context pack safety gates block LCM-style runtime mutation",
+        text=(
+            "The design explicitly avoids the hermes-lcm failure mode: no "
+            "resident per-session DAG or index, no transcript rewrite, no "
+            "session rotation, no config mutation, no gateway restart, and no "
+            "live context-engine replacement before canary sign-off."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/design/ichor-context-pack-compressor-augmentation.md",
+        source_id="ichor-context-pack-safety-gates-no-lcm-runtime-mutation",
+        tags=("ichor", "context", "pack", "compressor", "dry", "run", "dry-run", "manual", "canary", "lcm", "runtime", "mutation", "hermes", "ops"),
+        priority=97,
+    ),
+    Anchor(
+        section="risks",
+        title="Canary only after source-grounding and weight benchmarks",
+        text=(
+            "Before live profile use, the context pack must run golden queries, "
+            "long-history replay, source-grounding comparisons against the "
+            "default compressor, prompt-cache checks, and rollback proof for a "
+            "single disposable canary profile."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/design/ichor-context-pack-compressor-augmentation.md",
+        source_id="ichor-context-pack-canary-gates-before-live-use",
+        tags=("ichor", "context", "pack", "compressor", "canary", "benchmark", "source", "grounding", "rollback", "hermes", "ops"),
+        priority=96,
+    ),
 )
 
 

--- a/lib/ichor/context_pack.py
+++ b/lib/ichor/context_pack.py
@@ -213,13 +213,15 @@ def _sanitize_fts(query: str) -> str:
 
 
 def _needs_memory_context(query: str, god_name: str, phase: str, task_type: str) -> bool:
-    """Cheap no-read classifier: casual turns avoid DB and prompt growth."""
-    terms = _terms(query, god_name, phase, task_type)
-    if terms & MEMORY_TRIGGER_TERMS:
-        return True
-    if ROLE_TAGS & terms:
-        return True
-    return False
+    """Cheap no-read classifier: casual turns avoid DB and prompt growth.
+
+    God and role labels are ranking hints, not memory-need signals. A casual
+    chat turn should not become a DB read just because the active profile is
+    named ``thoth`` or ``hephaestus``.
+    """
+    del god_name, phase
+    terms = _terms(query, task_type)
+    return bool(terms & MEMORY_TRIGGER_TERMS)
 
 
 @lru_cache(maxsize=64)
@@ -266,6 +268,30 @@ def _row_value(row: sqlite3.Row, key: str) -> str:
     return "" if value is None else str(value)
 
 
+def _fallback_title(source: str, source_id: str) -> str:
+    label = (source or "ichor_source").replace("_", " ").strip()
+    label = label[:1].upper() + label[1:] if label else "Ichor source"
+    suffix = source_id.rsplit(":", 1)[-1] if source_id else ""
+    return f"{label} {suffix}".strip()
+
+
+def _clean_title(title: str, *, source: str, source_id: str) -> str:
+    raw = title or ""
+    raw_lower = raw.lower()
+    raw_fragment_markers = ("`", "|", "\n", "<", ">", "http", "www", "**", "#", "'", "=", ":", "/")
+    if any(marker in raw_lower for marker in raw_fragment_markers):
+        return _fallback_title(source, source_id)
+    full = " ".join(raw.split())
+    if not full:
+        return _fallback_title(source, source_id)
+    compact = full[:180]
+    if compact.endswith((",", ";")) or not compact[:1].isupper():
+        return _fallback_title(source, source_id)
+    if len(compact.split()) > 9 and not compact.endswith((".", ")")):
+        return _fallback_title(source, source_id)
+    return compact
+
+
 def _db_item(
     *,
     source: str,
@@ -279,7 +305,7 @@ def _db_item(
     if not clean:
         return None
     return {
-        "title": title[:180] or source_id,
+        "title": _clean_title(title, source=source, source_id=source_id),
         "text": clean[:420],
         "snippet": clean[:320],
         "source": source,

--- a/lib/ichor_mcp.py
+++ b/lib/ichor_mcp.py
@@ -28,6 +28,7 @@ from mcp.server.fastmcp import FastMCP
 
 from lib.ichor_gates import GatePipeline, LogicGate, PhaseDetectionGate, ReadCache, StateGate
 from lib.ichor_hybrid import MemoryTrait
+from lib.ichor.context_pack import build_context_pack
 
 logger = logging.getLogger("ichor-mcp")
 
@@ -46,6 +47,7 @@ TOOL_NAMES = [
     "ichor_fold",
     "ichor_expand",
     "ichor_compare",
+    "ichor_context_pack",
 ]
 
 mcp = FastMCP("Ichor MCP")
@@ -209,6 +211,14 @@ def _filter_historical(results: list[dict[str, Any]], include_historical: bool) 
     return filtered
 
 
+def _clamp_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (OverflowError, TypeError, ValueError):
+        parsed = default
+    return min(max(minimum, parsed), maximum)
+
+
 @mcp.tool(description="Store an Ichor memory event.")
 def ichor_store(
     namespace: str = "default",
@@ -284,6 +294,38 @@ def ichor_retrieve(
     except Exception as exc:
         result = {"error": f"ichor_retrieve failed: {exc}"}
         _audit("ichor_retrieve", payload, result, False, started_at)
+        return _json_dumps(result)
+
+
+@mcp.tool(description="Build a bounded, source-backed Ichor context pack. Defaults to dry-run/manual-safe mode.")
+def ichor_context_pack(
+    query: str,
+    god_name: str = "",
+    phase: str = "",
+    task_type: str = "",
+    max_items: int = 8,
+    max_tokens: int = 900,
+    max_ms: int = 350,
+    include_graph: bool = True,
+) -> str:
+    bounded_max_items = _clamp_int(max_items, default=8, minimum=1, maximum=8)
+    bounded_max_tokens = _clamp_int(max_tokens, default=900, minimum=1, maximum=900)
+    bounded_max_ms = _clamp_int(max_ms, default=350, minimum=1, maximum=350)
+    try:
+        result = build_context_pack(
+            query=query,
+            god_name=god_name,
+            phase=phase,
+            task_type=task_type,
+            max_items=bounded_max_items,
+            max_tokens=bounded_max_tokens,
+            max_ms=bounded_max_ms,
+            include_graph=include_graph,
+            dry_run=True,
+        )
+        return _json_dumps(result)
+    except Exception as exc:
+        result = {"error": f"ichor_context_pack failed: {exc}"}
         return _json_dumps(result)
 
 

--- a/scripts/dry-run-ichor-context-pack.py
+++ b/scripts/dry-run-ichor-context-pack.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Phase 0 dry-run measurement scaffold for Ichor context packs.
+"""Dry-run measurement scaffold for Ichor context packs.
 
-This command intentionally does not build or inject an Ichor context pack.
-It measures a bounded synthetic transcript and, when requested, compares cheap
-default ContextCompressor feasibility metrics without calling compress().
+This command builds the candidate pack for reporting only. It measures a
+bounded synthetic transcript and, when requested, compares cheap default
+ContextCompressor feasibility metrics without calling the compression method.
 """
 from __future__ import annotations
 
@@ -152,20 +152,6 @@ def _default_compressor_baseline(messages: list[dict[str, str]], tokens: int, wa
     }
 
 
-def _candidate_context_pack_scaffold(tokens: int, rows_examined: int) -> dict[str, Any]:
-    return {
-        "implemented": False,
-        "phase": "phase0_scaffold_only",
-        "would_build_context_pack": False,
-        "tokens_estimated": tokens,
-        "rows_examined": rows_examined,
-        "llm_calls": 0,
-        "api_calls": 0,
-        "db_reads": 0,
-        "db_writes": 0,
-    }
-
-
 def _build_payload(args: argparse.Namespace) -> dict[str, Any]:
     warnings: list[str] = []
     rss_before = _rss_kb()
@@ -173,6 +159,48 @@ def _build_payload(args: argparse.Namespace) -> dict[str, Any]:
 
     messages, rows_examined = _synthetic_messages(args, warnings)
     tokens = _estimate_tokens(messages, warnings)
+    try:
+        from lib.ichor.context_pack import build_context_pack
+        candidate_context_pack = build_context_pack(
+            args.query,
+            god_name=args.god,
+            phase=args.phase,
+            max_items=args.max_items,
+            dry_run=True,
+        )
+    except Exception as exc:
+        warnings.append(f"context pack builder unavailable: {exc}")
+        candidate_context_pack = {
+            "query": args.query,
+            "god": args.god,
+            "phase": args.phase,
+            "injectable_context": "",
+            "coverage": {
+                "status": "unknown",
+                "returned": 0,
+                "omitted": 0,
+                "warnings": ["context_pack_builder_unavailable"],
+            },
+            "current_decisions": [],
+            "hard_constraints": [],
+            "relevant_files": [],
+            "risks": [],
+            "related_entities": [],
+            "recent_changes": [],
+            "source_links": [],
+            "omitted": {"count": 0, "reasons": ["builder_unavailable"]},
+            "metrics": {
+                "wall_ms": 0,
+                "db_reads": 0,
+                "db_writes": 0,
+                "rows_examined": 0,
+                "tokens_estimated": 0,
+                "llm_calls": 0,
+                "api_calls": 0,
+                "rss_delta_kb": None,
+                "mode": "dry_run",
+            },
+        }
 
     payload: dict[str, Any] = {
         "mode": "dry_run",
@@ -187,10 +215,7 @@ def _build_payload(args: argparse.Namespace) -> dict[str, Any]:
         "would_restart_gateway": False,
         "warnings": warnings,
     }
-    payload["candidate_context_pack"] = _candidate_context_pack_scaffold(
-        tokens,
-        rows_examined,
-    )
+    payload["candidate_context_pack"] = candidate_context_pack
     if args.compare_default_compressor:
         payload["default_compressor_baseline"] = _default_compressor_baseline(
             messages, tokens, warnings,
@@ -207,11 +232,11 @@ def _build_payload(args: argparse.Namespace) -> dict[str, Any]:
         "wall_ms": wall_ms,
         "rss_delta_kb": rss_delta_kb,
         "peak_rss_kb": peak_rss_kb,
-        "db_reads": 0,
+        "db_reads": candidate_context_pack["metrics"]["db_reads"],
         "db_writes": 0,
         "fixture_reads": 1 if FIXTURE_PATH.exists() else 0,
-        "rows_examined": rows_examined,
-        "tokens_estimated": tokens,
+        "rows_examined": rows_examined + candidate_context_pack["metrics"]["rows_examined"],
+        "tokens_estimated": tokens + candidate_context_pack["metrics"]["tokens_estimated"],
         "llm_calls": 0,
         "api_calls": 0,
         "cache_read_tokens": 0,

--- a/scripts/dry-run-ichor-context-pack.py
+++ b/scripts/dry-run-ichor-context-pack.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Phase 0 dry-run measurement scaffold for Ichor context packs.
+
+This command intentionally does not build or inject an Ichor context pack.
+It measures a bounded synthetic transcript and, when requested, compares cheap
+default ContextCompressor feasibility metrics without calling compress().
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HERMES_AGENT = ROOT / "hermes-agent"
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "ichor_golden_queries.yaml"
+
+if str(HERMES_AGENT) not in sys.path:
+    sys.path.insert(0, str(HERMES_AGENT))
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _rss_kb() -> int | None:
+    try:
+        for line in Path("/proc/self/status").read_text(encoding="utf-8").splitlines():
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1])
+    except (OSError, IndexError, ValueError):
+        pass
+
+    try:
+        import psutil
+    except ImportError:
+        return None
+    return int(psutil.Process().memory_info().rss // 1024)
+
+
+def _peak_rss_kb() -> int | None:
+    try:
+        import resource
+    except ImportError:
+        return None
+    peak = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return peak if peak >= 0 else None
+
+
+def _load_fixture_queries(warnings: list[str]) -> list[dict[str, Any]]:
+    try:
+        import yaml
+    except ImportError:
+        warnings.append("PyYAML unavailable; using synthetic query only")
+        return []
+
+    try:
+        with FIXTURE_PATH.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except FileNotFoundError:
+        warnings.append(f"golden query fixture missing: {FIXTURE_PATH}")
+        return []
+    except (OSError, yaml.YAMLError) as exc:
+        warnings.append(f"golden query fixture could not be loaded: {exc}")
+        return []
+
+    queries = data.get("queries") if isinstance(data, dict) else None
+    if not isinstance(queries, list):
+        warnings.append("golden query fixture has no queries list")
+        return []
+    return [item for item in queries if isinstance(item, dict)]
+
+
+def _synthetic_messages(args: argparse.Namespace, warnings: list[str]) -> tuple[list[dict[str, str]], int]:
+    queries = _load_fixture_queries(warnings)
+    selected = [
+        item for item in queries
+        if str(item.get("query", "")).lower() == args.query.lower()
+    ][: max(args.max_items, 0)]
+    if not selected:
+        selected = [{
+            "query": args.query,
+            "god": args.god,
+            "phase": args.phase,
+            "must_include": [],
+            "notes": "synthetic dry-run transcript row",
+        }]
+
+    messages: list[dict[str, str]] = [
+        {
+            "role": "system",
+            "content": "Synthetic Phase 0 dry-run transcript. No runtime state is attached.",
+        }
+    ]
+    for row in selected:
+        must_include = ", ".join(str(token) for token in row.get("must_include", []) or [])
+        notes = str(row.get("notes", "") or "")
+        messages.append({
+            "role": "user",
+            "content": (
+                f"[{row.get('god', args.god)}:{row.get('phase', args.phase)}] "
+                f"{row.get('query', args.query)}"
+            ),
+        })
+        messages.append({
+            "role": "assistant",
+            "content": f"Fixture expectations: {must_include}. Notes: {notes}",
+        })
+    return messages, len(selected)
+
+
+def _estimate_tokens(messages: list[dict[str, str]], warnings: list[str]) -> int:
+    try:
+        from agent.model_metadata import estimate_messages_tokens_rough
+    except Exception as exc:
+        warnings.append(f"default token estimator unavailable: {exc}")
+        return sum((len(message.get("content", "")) + 3) // 4 for message in messages)
+    return int(estimate_messages_tokens_rough(messages))
+
+
+def _default_compressor_baseline(messages: list[dict[str, str]], tokens: int, warnings: list[str]) -> dict[str, Any]:
+    try:
+        from agent.context_compressor import ContextCompressor
+    except Exception as exc:
+        warnings.append(f"default compressor unavailable: {exc}")
+        return {
+            "available": False,
+            "tokens_estimated": tokens,
+            "llm_calls": 0,
+        }
+
+    compressor = ContextCompressor(
+        model="phase0-dry-run",
+        quiet_mode=True,
+        config_context_length=128_000,
+    )
+    return {
+        "available": True,
+        "engine": compressor.name,
+        "model": compressor.model,
+        "context_length": compressor.context_length,
+        "threshold_tokens": compressor.threshold_tokens,
+        "tail_token_budget": compressor.tail_token_budget,
+        "tokens_estimated": tokens,
+        "has_compressible_window": bool(compressor.has_content_to_compress(messages)),
+        "would_compress_by_threshold": bool(compressor.should_compress(tokens)),
+        "would_call_compress_method": False,
+        "llm_calls": 0,
+        "api_calls": 0,
+    }
+
+
+def _candidate_context_pack_scaffold(tokens: int, rows_examined: int) -> dict[str, Any]:
+    return {
+        "implemented": False,
+        "phase": "phase0_scaffold_only",
+        "would_build_context_pack": False,
+        "tokens_estimated": tokens,
+        "rows_examined": rows_examined,
+        "llm_calls": 0,
+        "api_calls": 0,
+        "db_reads": 0,
+        "db_writes": 0,
+    }
+
+
+def _build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    warnings: list[str] = []
+    rss_before = _rss_kb()
+    started = time.perf_counter()
+
+    messages, rows_examined = _synthetic_messages(args, warnings)
+    tokens = _estimate_tokens(messages, warnings)
+
+    payload: dict[str, Any] = {
+        "mode": "dry_run",
+        "god": args.god,
+        "phase": args.phase,
+        "query": args.query,
+        "max_items": args.max_items,
+        "would_mutate_runtime": False,
+        "would_rotate_session": False,
+        "would_rewrite_transcript": False,
+        "would_change_config": False,
+        "would_restart_gateway": False,
+        "warnings": warnings,
+    }
+    payload["candidate_context_pack"] = _candidate_context_pack_scaffold(
+        tokens,
+        rows_examined,
+    )
+    if args.compare_default_compressor:
+        payload["default_compressor_baseline"] = _default_compressor_baseline(
+            messages, tokens, warnings,
+        )
+
+    rss_after = _rss_kb()
+    peak_rss_kb = _peak_rss_kb() or rss_after
+    wall_ms = int((time.perf_counter() - started) * 1000)
+    rss_delta_kb = None if rss_before is None or rss_after is None else rss_after - rss_before
+    if rss_before is None or rss_after is None:
+        warnings.append("RSS metrics unavailable")
+
+    payload["metrics"] = {
+        "wall_ms": wall_ms,
+        "rss_delta_kb": rss_delta_kb,
+        "peak_rss_kb": peak_rss_kb,
+        "db_reads": 0,
+        "db_writes": 0,
+        "fixture_reads": 1 if FIXTURE_PATH.exists() else 0,
+        "rows_examined": rows_examined,
+        "tokens_estimated": tokens,
+        "llm_calls": 0,
+        "api_calls": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+    return payload
+
+
+def _format_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Ichor Context Pack Dry Run",
+        "",
+        f"mode: {payload['mode']}",
+        f"god: {payload['god']}",
+        f"phase: {payload['phase']}",
+        f"query: {payload['query']}",
+        f"would_mutate_runtime: {str(payload['would_mutate_runtime']).lower()}",
+        f"would_rotate_session: {str(payload['would_rotate_session']).lower()}",
+        f"would_rewrite_transcript: {str(payload['would_rewrite_transcript']).lower()}",
+        f"would_change_config: {str(payload['would_change_config']).lower()}",
+        f"would_restart_gateway: {str(payload['would_restart_gateway']).lower()}",
+        "",
+        "## Metrics",
+    ]
+    for key, value in payload["metrics"].items():
+        lines.append(f"{key}: {value}")
+    if "default_compressor_baseline" in payload:
+        lines.extend(["", "## Default Compressor Baseline"])
+        for key, value in payload["default_compressor_baseline"].items():
+            lines.append(f"{key}: {value}")
+    if "candidate_context_pack" in payload:
+        lines.extend(["", "## Candidate Context Pack"])
+        for key, value in payload["candidate_context_pack"].items():
+            lines.append(f"{key}: {value}")
+    if payload.get("warnings"):
+        lines.extend(["", "## Warnings"])
+        lines.extend(f"- {warning}" for warning in payload["warnings"])
+    return "\n".join(lines) + "\n"
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--god", required=True)
+    parser.add_argument("--phase", default="")
+    parser.add_argument("--query", required=True)
+    parser.add_argument("--max-items", type=int, default=8)
+    parser.add_argument("--compare-default-compressor", action="store_true")
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    payload = _build_payload(args)
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_markdown(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ichor_context_pack.py
+++ b/tests/test_ichor_context_pack.py
@@ -361,18 +361,55 @@ class TestContract:
         """Casual turns should stay a zero-read/no-injection fast path."""
         from lib.ichor.context_pack import build_context_pack  # type: ignore
 
-        pack = build_context_pack(
-            "random casual hello", god_name="hermes", phase="chat", max_items=8,
-        )
+        for god in ("hermes", "thoth", "hephaestus"):
+            pack = build_context_pack(
+                "random casual hello", god_name=god, phase="chat", max_items=8,
+            )
 
-        assert pack["coverage"]["status"] == "low"
-        assert pack["coverage"]["returned"] == 0
-        assert pack["injectable_context"] == ""
-        assert pack["metrics"]["db_reads"] == 0
-        assert pack["metrics"]["db_writes"] == 0
-        assert pack["metrics"]["llm_calls"] == 0
-        assert pack["metrics"]["api_calls"] == 0
-        assert "classifier_no_memory_need" in pack["omitted"]["reasons"]
+            assert pack["coverage"]["status"] == "low"
+            assert pack["coverage"]["returned"] == 0
+            assert pack["injectable_context"] == ""
+            assert pack["metrics"]["db_reads"] == 0
+            assert pack["metrics"]["db_writes"] == 0
+            assert pack["metrics"]["llm_calls"] == 0
+            assert pack["metrics"]["api_calls"] == 0
+            assert "classifier_no_memory_need" in pack["omitted"]["reasons"]
+
+    def test_db_candidate_titles_are_clean_human_labels(self) -> None:
+        """DB-backed source titles should not expose markdown/table fragments."""
+        from lib.ichor.context_pack import _db_item  # type: ignore
+
+        bad_titles = [
+            'engineering/debug context, while: ```text ichor_context_pack("Conductor',
+            "args: 'ok', description='LCM status",
+            "On, every God profile https://example.invalid/path",
+            "clear **build sequence** for Conductor",
+            "For the Ichor-backed context idea,",
+            "Use `context_pack` helper",
+            "Example www.example.com",
+            "Example HTTPS://example.invalid",
+            "Example WWW.example.com",
+            "Example WWW portal",
+            "Clean title\nwith table-ish fragment",
+            "Conductor #setup",
+            f"Title{'x' * 190} https://example.invalid",
+        ]
+
+        for title in bad_titles:
+            item = _db_item(
+                source="ichor_claims",
+                source_id="ichor_claims:123",
+                title=title,
+                text="A useful source-backed Ichor context claim.",
+                source_path="session-123",
+            )
+
+            assert item is not None
+            assert item["title"] == "Ichor claims 123"
+            assert "```" not in item["title"]
+            assert "|" not in item["title"]
+            assert "http" not in item["title"].lower()
+            assert "**" not in item["title"]
 
     def test_golden_query_distinguishes_hephaestus_and_thoth(self) -> None:
         """For 'Conductor v2', hephaestus sees NATS/MCP/endpoint/systemd

--- a/tests/test_ichor_context_pack.py
+++ b/tests/test_ichor_context_pack.py
@@ -1,27 +1,23 @@
 """
-Ichor-Retrieval Phase 0 baseline + Phase 9 contract tests.
+Ichor-Retrieval Phase 0 baseline + Phase 1 context-pack contract tests.
 
 Spec: ~/pantheon/plans/ichor-athenaeum-god-aware-retrieval-build-spec-v1.md
-      §Phase 0 (baseline) + §Phase 9 (ichor_context_pack)
+      §Phase 0 (baseline) + Phase 1 (build_context_pack)
 
 This file consumes the golden-queries fixture at
     tests/fixtures/ichor_golden_queries.yaml
 
-and asserts the Phase 9 contract: a god-aware context pack whose
+and asserts the Phase 1 contract: a god-aware context pack whose
 shape is determined by the (god, phase) tuple.
 
 Phase 0 baseline:
 
-  * `ichor_context_pack` is NOT implemented yet. We assert its
-    absence at every import path: `lib.ichor.context_pack`,
-    `pantheon-core.mcp_server`, and the broader `lib.ichor.*`
-    namespace. When Phase 9 ships, the importer resolves and these
-    tests start to fail — that's the signal to switch to the
-    TestContract class below.
+  * The golden-query fixture is readable and distinguishes god-specific
+    expectations before implementation work begins.
 
-Phase 9 contract (xfail until Phase 9 ships):
+Phase 1 contract:
 
-  * `ichor_context_pack(query, god_name, phase, task_type, max_items)`
+  * `build_context_pack(query, god_name, phase, task_type, max_items)`
     returns a dict with the spec's required keys.
   * The golden queries distinguish Hephaestus and Thoth expectations
     for the SAME query text.
@@ -47,7 +43,6 @@ import unittest
 from pathlib import Path
 from typing import Any, Dict, List
 
-import pytest
 import yaml
 
 
@@ -124,28 +119,11 @@ def _has_context_pack_callable() -> bool:
 
 
 # ─────────────────────────────────────────────────────────────────────
-# BASELINE: documents current state (ichor_context_pack not shipped)
+# BASELINE: fixture and dry-run safety guards
 # ─────────────────────────────────────────────────────────────────────
 
 class TestBaseline(unittest.TestCase):
-    """Phase 0 baseline — proves ichor_context_pack is not yet shipped.
-
-    These tests pass NOW. When Phase 9 lands, they should be removed
-    (or migrated to the TestContract class) because the function
-    exists and the baseline no longer applies.
-    """
-
-    def test_ichor_context_pack_not_yet_importable(self) -> None:
-        """WEAKNESS: ichor_context_pack does not exist yet.
-
-        Spec §Phase 9 requires the function at
-        `lib/ichor/context_pack.py`. Today the module is not there.
-        """
-        self.assertFalse(
-            _has_context_pack_callable(),
-            "ichor_context_pack / build_context_pack is already importable — "
-            "this baseline test is stale. Move to the TestContract class.",
-        )
+    """Phase 0 baseline fixture guards that remain valid in Phase 1."""
 
     def test_golden_queries_fixture_loads(self) -> None:
         """The golden-queries fixture is readable and well-formed.
@@ -283,10 +261,13 @@ class TestPhase0DryRunCLI(unittest.TestCase):
             self.assertIn(key, metrics)
         self.assertEqual(metrics["llm_calls"], 0)
         self.assertEqual(metrics["api_calls"], 0)
-        self.assertEqual(metrics["db_reads"], 0)
         self.assertEqual(metrics["db_writes"], 0)
         self.assertIn("candidate_context_pack", payload)
-        self.assertIs(payload["candidate_context_pack"]["would_build_context_pack"], False)
+        candidate = payload["candidate_context_pack"]
+        self.assertIn("injectable_context", candidate)
+        self.assertEqual(candidate["metrics"]["llm_calls"], 0)
+        self.assertEqual(candidate["metrics"]["api_calls"], 0)
+        self.assertEqual(candidate["metrics"]["db_writes"], 0)
         self.assertIn("default_compressor_baseline", payload)
         self.assertNotIn("compressed_messages", payload["default_compressor_baseline"])
         self.assertIs(payload["default_compressor_baseline"]["would_call_compress_method"], False)
@@ -336,25 +317,20 @@ class TestPhase0DryRunCLI(unittest.TestCase):
 
 
 # ─────────────────────────────────────────────────────────────────────
-# CONTRACT: Phase 9 deliverables (xfail until Phase 9 ships)
+# CONTRACT: Phase 1 deliverables
 # ─────────────────────────────────────────────────────────────────────
 
 class TestContract:
-    """Phase 9 contract — god-aware context pack.
-
-    These tests are xfail until Phase 9 ships. When they start
-    passing, remove the markers and the TestBaseline half becomes
-    historical reference.
-    """
+    """Phase 1 contract — god-aware context pack."""
 
     def test_ichor_context_pack_is_callable(self) -> None:
         assert _has_context_pack_callable(), (
-            "Phase 9 must ship ichor_context_pack (or build_context_pack) "
+            "Phase 1 must ship ichor_context_pack (or build_context_pack) "
             "at one of: " + ", ".join(_candidate_import_paths())
         )
 
     def test_context_pack_return_shape(self) -> None:
-        """Phase 9 must return the spec's required shape."""
+        """Phase 1 must return the spec's required shape."""
         from lib.ichor.context_pack import build_context_pack  # type: ignore
         pack = build_context_pack(
             "Conductor v2", god_name="hephaestus", phase="debug",
@@ -362,10 +338,11 @@ class TestContract:
         )
         required_keys = {
             "query", "god", "phase",
+            "injectable_context",
             "coverage",
             "current_decisions", "hard_constraints", "relevant_files",
             "risks", "related_entities", "recent_changes",
-            "source_links", "omitted",
+            "source_links", "omitted", "metrics",
         }
         for key in required_keys:
             assert key in pack, f"context_pack missing required key: {key!r}"
@@ -374,6 +351,28 @@ class TestContract:
         assert isinstance(pack["omitted"], dict)
         assert "count" in pack["omitted"]
         assert "reasons" in pack["omitted"]
+        assert isinstance(pack["injectable_context"], str)
+        assert pack["injectable_context"]
+        assert pack["metrics"]["llm_calls"] == 0
+        assert pack["metrics"]["api_calls"] == 0
+        assert pack["metrics"]["db_writes"] == 0
+
+    def test_context_pack_noop_path_has_no_db_or_prompt_growth(self) -> None:
+        """Casual turns should stay a zero-read/no-injection fast path."""
+        from lib.ichor.context_pack import build_context_pack  # type: ignore
+
+        pack = build_context_pack(
+            "random casual hello", god_name="hermes", phase="chat", max_items=8,
+        )
+
+        assert pack["coverage"]["status"] == "low"
+        assert pack["coverage"]["returned"] == 0
+        assert pack["injectable_context"] == ""
+        assert pack["metrics"]["db_reads"] == 0
+        assert pack["metrics"]["db_writes"] == 0
+        assert pack["metrics"]["llm_calls"] == 0
+        assert pack["metrics"]["api_calls"] == 0
+        assert "classifier_no_memory_need" in pack["omitted"]["reasons"]
 
     def test_golden_query_distinguishes_hephaestus_and_thoth(self) -> None:
         """For 'Conductor v2', hephaestus sees NATS/MCP/endpoint/systemd
@@ -457,25 +456,3 @@ class TestContract:
             assert token.lower() in pack_text, (
                 f"Rheta copywriting pack missing must_include token {token!r}"
             )
-
-
-# Mark contract tests as expected-to-fail (Phase 9 not yet shipped)
-_XFAIL_REASON = (
-    "Phase 9 (ichor_context_pack) not yet shipped — see "
-    "ichor-athenaeum-god-aware-retrieval-build-spec-v1.md §Phase 9"
-)
-
-for _name in (
-    "test_ichor_context_pack_is_callable",
-    "test_context_pack_return_shape",
-    "test_golden_query_distinguishes_hephaestus_and_thoth",
-    "test_context_pack_has_source_evidence_per_claim",
-    "test_rheta_pricing_golden_query",
-):
-    setattr(
-        TestContract,
-        _name,
-        pytest.mark.xfail(reason=_XFAIL_REASON, strict=False)(
-            getattr(TestContract, _name)
-        ),
-    )

--- a/tests/test_ichor_context_pack.py
+++ b/tests/test_ichor_context_pack.py
@@ -39,7 +39,9 @@ No service restart required.
 from __future__ import annotations
 
 import importlib
+import json
 import os
+import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -54,6 +56,7 @@ if _ROOT not in sys.path:
     sys.path.insert(0, _ROOT)
 
 GOLDEN_QUERIES_PATH = Path(_ROOT) / "tests" / "fixtures" / "ichor_golden_queries.yaml"
+DRY_RUN_SCRIPT_PATH = Path(_ROOT) / "scripts" / "dry-run-ichor-context-pack.py"
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -213,6 +216,123 @@ class TestBaseline(unittest.TestCase):
                     len(token), 0,
                     f"query {q['id']}!r: empty must_include token",
                 )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# PHASE 0 DRY-RUN: measurement scaffold, no context-pack behavior
+# ─────────────────────────────────────────────────────────────────────
+
+class TestPhase0DryRunCLI(unittest.TestCase):
+    """Phase 0 dry-run measurement harness."""
+
+    def _run_json(self, *extra_args: str) -> Dict[str, Any]:
+        env = os.environ.copy()
+        env["PYTHONPATH"] = _ROOT
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(DRY_RUN_SCRIPT_PATH),
+                "--god",
+                "thoth",
+                "--phase",
+                "research",
+                "--query",
+                "Conductor v2",
+                "--max-items",
+                "8",
+                "--format",
+                "json",
+                *extra_args,
+            ],
+            cwd=_ROOT,
+            env=env,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        return json.loads(proc.stdout)
+
+    def test_dry_run_json_emits_runtime_safety_fields(self) -> None:
+        payload = self._run_json()
+        for key in (
+            "would_mutate_runtime",
+            "would_rotate_session",
+            "would_rewrite_transcript",
+            "would_change_config",
+            "would_restart_gateway",
+        ):
+            self.assertIn(key, payload)
+            self.assertIs(payload[key], False)
+
+    def test_dry_run_json_emits_metric_schema_without_llm_or_writes(self) -> None:
+        payload = self._run_json("--compare-default-compressor")
+        metrics = payload["metrics"]
+        for key in (
+            "wall_ms",
+            "rss_delta_kb",
+            "peak_rss_kb",
+            "db_reads",
+            "db_writes",
+            "rows_examined",
+            "tokens_estimated",
+            "llm_calls",
+            "api_calls",
+            "cache_read_tokens",
+            "cache_write_tokens",
+        ):
+            self.assertIn(key, metrics)
+        self.assertEqual(metrics["llm_calls"], 0)
+        self.assertEqual(metrics["api_calls"], 0)
+        self.assertEqual(metrics["db_reads"], 0)
+        self.assertEqual(metrics["db_writes"], 0)
+        self.assertIn("candidate_context_pack", payload)
+        self.assertIs(payload["candidate_context_pack"]["would_build_context_pack"], False)
+        self.assertIn("default_compressor_baseline", payload)
+        self.assertNotIn("compressed_messages", payload["default_compressor_baseline"])
+        self.assertIs(payload["default_compressor_baseline"]["would_call_compress_method"], False)
+        self.assertEqual(payload["default_compressor_baseline"]["api_calls"], 0)
+
+    def test_dry_run_script_avoids_forbidden_runtime_mutation_paths(self) -> None:
+        script = DRY_RUN_SCRIPT_PATH.read_text(encoding="utf-8")
+        for forbidden in (
+            "_compress_context",
+            ".compress(",
+            "SessionDB",
+            ".end_session(",
+            "continuation session",
+            "config.yaml",
+            "systemctl",
+            "hermes-gateway",
+        ):
+            self.assertNotIn(forbidden, script)
+
+    def test_dry_run_markdown_reports_non_mutation(self) -> None:
+        env = os.environ.copy()
+        env["PYTHONPATH"] = _ROOT
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(DRY_RUN_SCRIPT_PATH),
+                "--god",
+                "thoth",
+                "--phase",
+                "research",
+                "--query",
+                "Conductor v2",
+                "--max-items",
+                "8",
+                "--compare-default-compressor",
+                "--format",
+                "markdown",
+            ],
+            cwd=_ROOT,
+            env=env,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        self.assertIn("would_mutate_runtime: false", proc.stdout)
+        self.assertIn("llm_calls: 0", proc.stdout)
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_ichor_context_pack.py
+++ b/tests/test_ichor_context_pack.py
@@ -493,3 +493,55 @@ class TestContract:
             assert token.lower() in pack_text, (
                 f"Rheta copywriting pack missing must_include token {token!r}"
             )
+
+    def test_context_pack_recalls_own_dry_run_design_for_followup_query(self) -> None:
+        """A real operator follow-up should retrieve the context-pack design itself.
+
+        This guards the intended effect beyond canned Conductor examples:
+        asking where the Ichor context-pack work stands should return a
+        source-backed pack with the dry-run/manual/no-LCM safety decision.
+        """
+        from lib.ichor.context_pack import build_context_pack  # type: ignore
+
+        pack = build_context_pack(
+            "where did we leave the Ichor context pack?",
+            god_name="hermes",
+            phase="ops",
+            max_items=8,
+            dry_run=True,
+        )
+        pack_text = pack["injectable_context"].lower()
+        source_paths = "\n".join(link["source_path"] for link in pack["source_links"])
+
+        assert pack["coverage"]["status"] == "ok"
+        assert pack["coverage"]["returned"] >= 2
+        assert "dry-run" in pack_text or "dry_run" in pack_text
+        assert "manual" in pack_text
+        assert "lcm" in pack_text
+        assert "ichor-context-pack-compressor-augmentation" in source_paths
+        assert pack["metrics"]["llm_calls"] == 0
+        assert pack["metrics"]["api_calls"] == 0
+        assert pack["metrics"]["db_writes"] == 0
+        assert pack["metrics"]["tokens_estimated"] <= 900
+
+    def test_context_pack_operator_query_stays_bounded_without_runtime_mutation(self) -> None:
+        """Follow-up recall can improve without becoming a live compression path."""
+        from lib.ichor.context_pack import build_context_pack  # type: ignore
+
+        pack = build_context_pack(
+            "should we enable the Ichor context pack canary now?",
+            god_name="hermes",
+            phase="ops",
+            max_items=8,
+            max_tokens=900,
+            max_ms=350,
+            dry_run=True,
+        )
+
+        assert pack["coverage"]["returned"] > 0
+        assert pack["metrics"]["mode"] == "dry_run"
+        assert pack["metrics"]["llm_calls"] == 0
+        assert pack["metrics"]["api_calls"] == 0
+        assert pack["metrics"]["db_writes"] == 0
+        assert pack["metrics"]["tokens_estimated"] <= 900
+        assert pack["metrics"]["wall_ms"] <= 350

--- a/tests/test_ichor_mcp.py
+++ b/tests/test_ichor_mcp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.machinery
+import inspect
 import json
 import os
 import tempfile
@@ -8,7 +9,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-MODULE_PATH = Path('/home/konan/pantheon/lib/ichor_mcp.py')
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'lib' / 'ichor_mcp.py'
 
 
 def load_module(home_dir: str):
@@ -21,10 +22,107 @@ def load_module(home_dir: str):
 class TestIchorMCP(unittest.TestCase):
     def test_tool_registry_has_expected_phase_a_tools(self) -> None:
         mod = load_module(tempfile.mkdtemp(prefix='ichor-mcp-tools-', dir='/home/konan'))
-        self.assertEqual(len(mod.list_tools()), 9)
+        self.assertEqual(len(mod.list_tools()), 10)
         self.assertEqual(mod.list_tools(), mod.REGISTERED_TOOL_NAMES)
         self.assertIn('ichor_store', mod.list_tools())
         self.assertIn('ichor_compare', mod.list_tools())
+        self.assertIn('ichor_context_pack', mod.list_tools())
+
+    def test_context_pack_tool_defaults_to_dry_run_and_returns_pack(self) -> None:
+        mod = load_module(tempfile.mkdtemp(prefix='ichor-mcp-context-pack-', dir='/home/konan'))
+        result = json.loads(mod.ichor_context_pack(
+            query='Conductor v2',
+            god_name='thoth',
+            phase='research',
+            max_items=8,
+        ))
+
+        self.assertEqual(result['query'], 'Conductor v2')
+        self.assertEqual(result['god'], 'thoth')
+        self.assertEqual(result['phase'], 'research')
+        self.assertEqual(result['metrics']['mode'], 'dry_run')
+        self.assertEqual(result['metrics']['llm_calls'], 0)
+        self.assertEqual(result['metrics']['api_calls'], 0)
+        self.assertEqual(result['metrics']['db_writes'], 0)
+        self.assertGreaterEqual(result['coverage']['returned'], 1)
+        self.assertIn('injectable_context', result)
+
+    def test_context_pack_tool_does_not_expose_live_mode_knob(self) -> None:
+        mod = load_module(tempfile.mkdtemp(prefix='ichor-mcp-context-pack-safe-', dir='/home/konan'))
+
+        signature = inspect.signature(mod.ichor_context_pack)
+
+        self.assertNotIn('dry_run', signature.parameters)
+
+    def test_context_pack_tool_clamps_public_budgets(self) -> None:
+        mod = load_module(tempfile.mkdtemp(prefix='ichor-mcp-context-pack-budget-', dir='/home/konan'))
+        result = json.loads(mod.ichor_context_pack(
+            query='Conductor v2',
+            god_name='hephaestus',
+            phase='debug',
+            max_items=999,
+            max_tokens=999999,
+            max_ms=999999,
+        ))
+
+        self.assertEqual(result['metrics']['mode'], 'dry_run')
+        self.assertLessEqual(result['coverage']['returned'], 8)
+        self.assertLessEqual(result['metrics']['tokens_estimated'], 900)
+        self.assertEqual(result['metrics']['llm_calls'], 0)
+        self.assertEqual(result['metrics']['api_calls'], 0)
+        self.assertEqual(result['metrics']['db_writes'], 0)
+
+    def test_context_pack_tool_handles_bad_budget_values_as_defaults(self) -> None:
+        mod = load_module(tempfile.mkdtemp(prefix='ichor-mcp-context-pack-bad-budget-', dir='/home/konan'))
+        result = json.loads(mod.ichor_context_pack(
+            query='Conductor v2',
+            god_name='thoth',
+            phase='research',
+            max_items='nope',
+            max_tokens='nah',
+            max_ms='no-way',
+        ))
+
+        self.assertNotIn('error', result)
+        self.assertEqual(result['metrics']['mode'], 'dry_run')
+        self.assertLessEqual(result['coverage']['returned'], 8)
+        self.assertLessEqual(result['metrics']['tokens_estimated'], 900)
+        self.assertEqual(result['metrics']['llm_calls'], 0)
+        self.assertEqual(result['metrics']['api_calls'], 0)
+        self.assertEqual(result['metrics']['db_writes'], 0)
+
+    def test_context_pack_tool_handles_non_finite_budget_values_as_defaults(self) -> None:
+        mod = load_module(tempfile.mkdtemp(prefix='ichor-mcp-context-pack-nonfinite-', dir='/home/konan'))
+        result = json.loads(mod.ichor_context_pack(
+            query='Conductor v2',
+            god_name='thoth',
+            phase='research',
+            max_items=float('inf'),
+            max_tokens=float('inf'),
+            max_ms=float('inf'),
+        ))
+
+        self.assertNotIn('error', result)
+        self.assertEqual(result['metrics']['mode'], 'dry_run')
+        self.assertLessEqual(result['coverage']['returned'], 8)
+        self.assertLessEqual(result['metrics']['tokens_estimated'], 900)
+        self.assertEqual(result['metrics']['llm_calls'], 0)
+        self.assertEqual(result['metrics']['api_calls'], 0)
+        self.assertEqual(result['metrics']['db_writes'], 0)
+
+    def test_context_pack_tool_does_not_create_audit_db(self) -> None:
+        with tempfile.TemporaryDirectory(dir='/home/konan') as td:
+            mod = load_module(td)
+
+            result = json.loads(mod.ichor_context_pack(
+                query='Conductor v2',
+                god_name='thoth',
+                phase='research',
+            ))
+
+            self.assertNotIn('error', result)
+            self.assertEqual(result['metrics']['mode'], 'dry_run')
+            self.assertFalse((Path(td) / '.hermes' / 'ichor.db').exists())
 
     def test_store_reconcile_supersedes_old_memory(self) -> None:
         with tempfile.TemporaryDirectory(dir='/home/konan') as td:


### PR DESCRIPTION
## Summary

Adds the Ichor context-pack compressor-weight augmentation in manual/dry-run form:

- Adds `lib/ichor/context_pack.py`, a deterministic source-backed context-pack builder.
- Adds `scripts/dry-run-ichor-context-pack.py`, an operator CLI for dry-run and default-compressor comparison output.
- Exposes `ichor_context_pack` on `lib/ichor_mcp.py` as a manual-safe MCP tool.
- Adds golden-query/context-pack tests plus MCP wrapper safety contracts.
- Adds `docs/ichor-context-pack-dry-run.md` operator notes.

## Safety / rollout boundary

This PR does **not** wire the pack into live session compression or any god gateway path.

Explicitly unchanged / not performed:

- no `context.engine` change
- no profile or fleet `compression.*` change
- no gateway restart
- no LCM enablement
- no automatic context injection path
- no runtime/session mutation
- no transcript rewrite

The MCP wrapper always calls the builder with `dry_run=True`, does not expose a public `dry_run`/live-mode parameter, clamps public budgets, and does not write MCP audit rows for context-pack dry-run calls.

Canary/live wiring should be a separate, explicit approval step after review.

## Verification

Ran from `/home/konan/pantheon-ichor-context-pack-dry-run`:

```bash
PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run:$PYTHONPATH \
/usr/local/lib/hermes-agent/venv/bin/python -m pytest \
  tests/test_ichor_context_pack.py \
  tests/test_ichor_mcp.py \
  -q
```

Result:

```text
26 passed, 12 warnings
```

Dry-run CLI smoke:

```bash
PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run:$PYTHONPATH \
/usr/local/lib/hermes-agent/venv/bin/python scripts/dry-run-ichor-context-pack.py \
  --god thoth \
  --phase research \
  --query "Conductor v2" \
  --max-items 8 \
  --compare-default-compressor \
  --format json
```

Observed safety fields:

```text
would_mutate_runtime: False
would_rotate_session: False
would_rewrite_transcript: False
would_change_config: False
would_restart_gateway: False
```

Observed metrics sample:

```text
api_calls: 0
db_reads: 0
db_writes: 0
fixture_reads: 1
llm_calls: 0
rows_examined: 5
tokens_estimated: 478
```

MCP/manual smoke:

```text
--list-tools count: 10
includes: ichor_context_pack
dry_run_param exposed: False
db_exists after temp-HOME MCP context-pack call: False
```

## Review notes

Independent code review was run on the Phase 2 diff. It initially caught two issues that were fixed before this PR:

1. Public `dry_run=False`/live-mode exposure risk — fixed by removing `dry_run` from the MCP public signature and forcing `dry_run=True` internally.
2. MCP audit DB write during dry-run context-pack calls — fixed by removing audit writes from this tool path and adding a temp-HOME no-DB-creation regression test.
