### PR TITLE
[verified] Add Ichor context-pack rollout simulation gate

### DIFF
--- a/scripts/simulate-ichor-context-pack-rollout.py
+++ b/scripts/simulate-ichor-context-pack-rollout.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Controlled prompt-injection simulation for Ichor context packs.
+
+This is the gate after replay readiness and before any live/default-on wiring.
+It composes prompt-shaped messages with the candidate Ichor context pack inserted
+as an extra system message only when source-backed memory is actually returned.
+
+Safety boundary:
+- no model calls
+- no config writes
+- no gateway/service control
+- no session rotation
+- no transcript rewrite
+- no runtime DB writes
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+HERMES_AGENT = ROOT / "hermes-agent"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(HERMES_AGENT) not in sys.path:
+    sys.path.insert(0, str(HERMES_AGENT))
+
+
+@dataclass(frozen=True)
+class SimulationCase:
+    case_id: str
+    god: str
+    phase: str
+    query: str
+    expected_injection: bool
+    min_sources: int = 1
+    max_items: int = 8
+    max_tokens: int = 900
+    max_ms: int = 350
+
+
+MATRIX: tuple[SimulationCase, ...] = (
+    SimulationCase(
+        case_id="hermes-context-pack-followup",
+        god="hermes",
+        phase="ops",
+        query="where did we leave the Ichor context pack?",
+        expected_injection=True,
+        min_sources=2,
+    ),
+    SimulationCase(
+        case_id="hermes-canary-decision",
+        god="hermes",
+        phase="ops",
+        query="should we enable the Ichor context pack canary now?",
+        expected_injection=True,
+        min_sources=1,
+    ),
+    SimulationCase("hephaestus-conductor-debug", "hephaestus", "debug", "Conductor v2", True, min_sources=3),
+    SimulationCase("thoth-conductor-research", "thoth", "research", "Conductor v2", True, min_sources=3),
+    SimulationCase("rheta-pricing-copywriting", "rheta", "copywriting", "Pantheon pricing managed retainer dedicated infrastructure", True, min_sources=2),
+    SimulationCase("hermes-noop-chat", "hermes", "chat", "random casual hello", False, min_sources=0),
+    SimulationCase("thoth-noop-chat", "thoth", "chat", "random casual hello", False, min_sources=0),
+    SimulationCase("hephaestus-noop-chat", "hephaestus", "chat", "random casual hello", False, min_sources=0),
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _default_artifact_dir() -> Path:
+    return Path("/tmp") / f"ichor-context-pack-rollout-sim-{_utc_stamp()}"
+
+
+def _estimate_tokens_text(text: str) -> int:
+    try:
+        from agent.model_metadata import estimate_tokens_rough
+
+        return int(estimate_tokens_rough(text))
+    except Exception:
+        return max(0, (len(text) + 3) // 4)
+
+
+def _estimate_messages_tokens(messages: list[dict[str, str]]) -> int:
+    try:
+        from agent.model_metadata import estimate_messages_tokens_rough
+
+        return int(estimate_messages_tokens_rough(messages))
+    except Exception:
+        return sum(_estimate_tokens_text(message.get("content", "")) for message in messages)
+
+
+def _base_messages(case: SimulationCase) -> list[dict[str, str]]:
+    return [
+        {
+            "role": "system",
+            "content": (
+                f"You are {case.god}, a Pantheon operator. Phase: {case.phase}. "
+                "Use supplied source-backed context when present; ignore it when absent."
+            ),
+        },
+        {"role": "user", "content": case.query},
+    ]
+
+
+def _context_message(injectable_context: str) -> dict[str, str]:
+    return {
+        "role": "system",
+        "content": (
+            "The following block is a dry-run Ichor context pack candidate. "
+            "It is source-backed and bounded; do not treat it as a runtime mutation.\n\n"
+            f"{injectable_context}"
+        ),
+    }
+
+
+def _source_titles_clean(source_links: list[dict[str, Any]]) -> bool:
+    forbidden = ("```", "\n", "http://", "https://", "www.", "|")
+    for link in source_links:
+        title = str(link.get("title", ""))
+        if not title.strip():
+            return False
+        lowered = title.lower()
+        if any(token in lowered for token in forbidden):
+            return False
+    return True
+
+
+def simulate_case(case: SimulationCase, artifact_dir: Path) -> tuple[dict[str, Any], Path]:
+    from lib.ichor.context_pack import build_context_pack
+
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    started = time.perf_counter()
+    before_messages = _base_messages(case)
+    before_tokens = _estimate_messages_tokens(before_messages)
+    pack = build_context_pack(
+        case.query,
+        god_name=case.god,
+        phase=case.phase,
+        max_items=case.max_items,
+        max_tokens=case.max_tokens,
+        max_ms=case.max_ms,
+        include_graph=True,
+        dry_run=True,
+    )
+    injectable = str(pack.get("injectable_context", "") or "")
+    coverage = pack.get("coverage", {})
+    metrics = pack.get("metrics", {})
+    source_links = list(pack.get("source_links") or [])
+    injected = bool(injectable and int(coverage.get("returned", 0) or 0) > 0)
+    after_messages = list(before_messages)
+    if injected:
+        after_messages.insert(1, _context_message(injectable))
+    after_tokens = _estimate_messages_tokens(after_messages)
+    source_link_count = len(source_links)
+    wall_ms = int((time.perf_counter() - started) * 1000)
+    source_quality_ok = source_link_count >= case.min_sources and _source_titles_clean(source_links)
+    noop_clean = (
+        not case.expected_injection
+        and not injected
+        and source_link_count == 0
+        and int(metrics.get("db_reads", 0) or 0) == 0
+        and int(metrics.get("tokens_estimated", 0) or 0) == 0
+        and not injectable
+    )
+    injection_quality_ok = injected and source_quality_ok and after_tokens > before_tokens
+    row_quality_pass = injection_quality_ok if case.expected_injection else noop_clean
+    row = {
+        "case_id": case.case_id,
+        "god": case.god,
+        "phase": case.phase,
+        "query": case.query,
+        "expected_injection": case.expected_injection,
+        "injected": injected,
+        "coverage_status": coverage.get("status"),
+        "returned": int(coverage.get("returned", 0) or 0),
+        "source_link_count": source_link_count,
+        "source_titles": [str(link.get("title", "")) for link in source_links],
+        "source_paths": [str(link.get("source_path", "")) for link in source_links],
+        "source_titles_clean": _source_titles_clean(source_links),
+        "prompt_message_count_before": len(before_messages),
+        "prompt_message_count_after": len(after_messages),
+        "prompt_tokens_before": before_tokens,
+        "prompt_tokens_after": after_tokens,
+        "prompt_token_delta": after_tokens - before_tokens,
+        "injectable_context_length": len(injectable),
+        "tokens_estimated": int(metrics.get("tokens_estimated", 0) or 0),
+        "db_reads": int(metrics.get("db_reads", 0) or 0),
+        "db_writes": int(metrics.get("db_writes", 0) or 0),
+        "llm_calls": int(metrics.get("llm_calls", 0) or 0),
+        "api_calls": int(metrics.get("api_calls", 0) or 0),
+        "wall_ms": int(metrics.get("wall_ms", wall_ms) or wall_ms),
+        "would_mutate_runtime": False,
+        "would_change_config": False,
+        "would_restart_gateway": False,
+        "would_rotate_session": False,
+        "would_rewrite_transcript": False,
+        "row_safety_pass": (
+            int(metrics.get("db_writes", 0) or 0) == 0
+            and int(metrics.get("llm_calls", 0) or 0) == 0
+            and int(metrics.get("api_calls", 0) or 0) == 0
+        ),
+        "row_quality_pass": row_quality_pass,
+    }
+    case_path = artifact_dir / f"{case.case_id}.json"
+    case_path.write_text(
+        json.dumps({"row": row, "pack": pack, "messages_before": before_messages, "messages_after": after_messages}, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return row, case_path
+
+
+def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    noop_rows = [row for row in rows if not row["expected_injection"]]
+    injection_rows = [row for row in rows if row["expected_injection"]]
+    all_no_llm_api = all(row["llm_calls"] == 0 and row["api_calls"] == 0 for row in rows)
+    all_no_db_writes = all(row["db_writes"] == 0 for row in rows)
+    all_safety_flags_false = all(
+        not row["would_mutate_runtime"]
+        and not row["would_change_config"]
+        and not row["would_restart_gateway"]
+        and not row["would_rotate_session"]
+        and not row["would_rewrite_transcript"]
+        for row in rows
+    )
+    injection_rows_ok = all(row["row_quality_pass"] for row in injection_rows)
+    noop_rows_clean = all(row["row_quality_pass"] for row in noop_rows)
+    safety_pass = all_no_llm_api and all_no_db_writes and all_safety_flags_false
+    quality_pass = injection_rows_ok and noop_rows_clean
+    blockers: list[str] = []
+    if not safety_pass:
+        blockers.append("safety_invariants_failed")
+    if not injection_rows_ok:
+        blockers.append("injection_rows_failed_quality")
+    if not noop_rows_clean:
+        blockers.append("noop_rows_not_clean")
+    return {
+        "rows_run": len(rows),
+        "injection_rows": len(injection_rows),
+        "noop_rows": len(noop_rows),
+        "safety_pass": safety_pass,
+        "quality_pass": quality_pass,
+        "rollout_sim_ready": safety_pass and quality_pass,
+        "all_no_llm_api": all_no_llm_api,
+        "all_no_db_writes": all_no_db_writes,
+        "all_safety_flags_false": all_safety_flags_false,
+        "injection_rows_ok": injection_rows_ok,
+        "noop_rows_clean": noop_rows_clean,
+        "max_prompt_token_delta": max((row["prompt_token_delta"] for row in rows), default=0),
+        "max_prompt_tokens_after": max((row["prompt_tokens_after"] for row in rows), default=0),
+        "total_db_reads": sum(row["db_reads"] for row in rows),
+        "total_db_writes": sum(row["db_writes"] for row in rows),
+        "blockers": blockers,
+    }
+
+
+def format_report(payload: dict[str, Any]) -> str:
+    summary = payload["summary"]
+    lines = [
+        "# Ichor Context-Pack Prompt Injection Simulation",
+        "",
+        f"Generated: {payload['generated_at']}",
+        f"Mode: {payload['mode']}",
+        f"Artifact dir: {payload['artifact_dir']}",
+        "",
+        "## Verdict",
+        f"- safety_pass: {str(summary['safety_pass']).lower()}",
+        f"- quality_pass: {str(summary['quality_pass']).lower()}",
+        f"- rollout_sim_ready: {str(summary['rollout_sim_ready']).lower()}",
+        f"- blockers: {', '.join(summary['blockers']) if summary['blockers'] else 'none'}",
+        "",
+        "## Safety boundary",
+        "- prompt simulation only: true",
+        "- live profile mutation: false",
+        "- gateway restart: false",
+        "- session rotation: false",
+        "- transcript rewrite: false",
+        "- model/API calls: false",
+        "",
+        "## Rows",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            f"- {row['case_id']}: injected={str(row['injected']).lower()} "
+            f"sources={row['source_link_count']} prompt_delta={row['prompt_token_delta']} "
+            f"quality={str(row['row_quality_pass']).lower()}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def run_simulation(artifact_dir: Path) -> dict[str, Any]:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+    case_paths: list[str] = []
+    for case in MATRIX:
+        row, path = simulate_case(case, artifact_dir)
+        rows.append(row)
+        case_paths.append(str(path))
+    payload = {
+        "mode": "prompt_injection_simulation",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "artifact_dir": str(artifact_dir),
+        "would_mutate_runtime": False,
+        "would_change_config": False,
+        "would_restart_gateway": False,
+        "would_rotate_session": False,
+        "would_rewrite_transcript": False,
+        "rows": rows,
+        "summary": summarize(rows),
+        "case_paths": case_paths,
+    }
+    summary_path = artifact_dir / "summary.json"
+    report_path = artifact_dir / "report.md"
+    payload["summary_path"] = str(summary_path)
+    payload["report_path"] = str(report_path)
+    summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    report_path.write_text(format_report(payload), encoding="utf-8")
+    return payload
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-dir", type=Path, default=None)
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    payload = run_simulation(args.artifact_dir or _default_artifact_dir())
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(format_report(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ichor_context_pack_rollout_simulation.py
+++ b/tests/test_ichor_context_pack_rollout_simulation.py
@@ -1,0 +1,117 @@
+"""Controlled rollout simulation tests for Ichor context packs.
+
+The replay harness proves the builder is safe and source-backed. The next gate is
+slightly closer to rollout: compose a prompt-shaped message list that includes
+an Ichor context pack only when memory is actually needed, while still staying
+fully offline/read-only.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "simulate-ichor-context-pack-rollout.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("simulate_ichor_context_pack_rollout", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_positive_case_injects_source_backed_context_without_live_mutation(tmp_path: Path) -> None:
+    module = load_module()
+
+    row, artifact = module.simulate_case(
+        module.SimulationCase(
+            case_id="hermes-context-pack-followup",
+            god="hermes",
+            phase="ops",
+            query="where did we leave the Ichor context pack?",
+            expected_injection=True,
+            min_sources=2,
+        ),
+        tmp_path,
+    )
+
+    assert artifact.exists()
+    assert row["injected"] is True
+    assert row["source_link_count"] >= 2
+    assert row["prompt_message_count_after"] == row["prompt_message_count_before"] + 1
+    assert row["prompt_token_delta"] > 0
+    assert row["llm_calls"] == 0
+    assert row["api_calls"] == 0
+    assert row["db_writes"] == 0
+    assert row["would_mutate_runtime"] is False
+    assert row["would_change_config"] is False
+    assert row["would_restart_gateway"] is False
+    assert row["would_rotate_session"] is False
+    assert row["would_rewrite_transcript"] is False
+
+
+def test_noop_case_does_not_inject_or_read_memory(tmp_path: Path) -> None:
+    module = load_module()
+
+    row, artifact = module.simulate_case(
+        module.SimulationCase(
+            case_id="hermes-casual-noop",
+            god="hermes",
+            phase="chat",
+            query="random casual hello",
+            expected_injection=False,
+            min_sources=0,
+        ),
+        tmp_path,
+    )
+
+    assert artifact.exists()
+    assert row["injected"] is False
+    assert row["source_link_count"] == 0
+    assert row["prompt_message_count_after"] == row["prompt_message_count_before"]
+    assert row["prompt_token_delta"] == 0
+    assert row["db_reads"] == 0
+    assert row["tokens_estimated"] == 0
+
+
+def test_cli_writes_rollout_simulation_artifacts_and_summary(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "rollout-sim"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--format",
+            "json",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = json.loads(proc.stdout)
+    summary = payload["summary"]
+
+    assert payload["mode"] == "prompt_injection_simulation"
+    assert summary["rows_run"] >= 6
+    assert summary["safety_pass"] is True
+    assert summary["quality_pass"] is True
+    assert summary["rollout_sim_ready"] is True
+    assert summary["all_no_llm_api"] is True
+    assert summary["all_no_db_writes"] is True
+    assert summary["noop_rows_clean"] is True
+    assert payload["would_mutate_runtime"] is False
+    assert payload["would_change_config"] is False
+    assert payload["would_restart_gateway"] is False
+    assert Path(payload["summary_path"]).exists()
+    assert Path(payload["report_path"]).exists()
+    assert len(payload["case_paths"]) == summary["rows_run"]


### PR DESCRIPTION
## Summary

Adds a controlled prompt-injection simulation gate for Ichor context packs.

This is the gate between replay readiness and any live/default-on rollout. It composes prompt-shaped message lists and inserts the candidate Ichor context pack only when source-backed context is returned.

## Safety boundary

The simulation harness remains offline/read-only:

- no model calls
- no API calls
- no config writes
- no gateway/service control
- no session rotation
- no transcript rewrite
- no runtime DB writes

## Test Plan

- RED confirmed first: `tests/test_ichor_context_pack_rollout_simulation.py` failed because `scripts/simulate-ichor-context-pack-rollout.py` did not exist.
- AST/compile:
  - `scripts/simulate-ichor-context-pack-rollout.py`
  - `tests/test_ichor_context_pack_rollout_simulation.py`
  - `scripts/replay-ichor-context-pack-canary.py`
  - `lib/ichor/context_pack.py`
  - `lib/ichor_mcp.py`
- Focused suite:
  - `pytest tests/test_ichor_context_pack_rollout_simulation.py tests/test_ichor_context_pack.py tests/test_ichor_context_pack_canary.py tests/test_ichor_mcp.py -q`
  - Result: `36 passed, 12 warnings in 4.64s`
- Clean-base proof:
  - Applied exact PR diff onto fresh worktree from `origin/ops/pantheon-top-moves-20260812`
  - Result: `36 passed, 12 warnings in 4.25s`
- Live-safe artifact run:
  - `/tmp/ichor-context-pack-rollout-sim-20260814T135125Z`
  - `rollout_sim_ready=true`
  - `rows_run=8`
  - `injection_rows=5`
  - `noop_rows=3`
  - `all_no_llm_api=true`
  - `all_no_db_writes=true`
  - `noop_rows_clean=true`

## Rollout meaning

`rollout_sim_ready=true` means ready to discuss one controlled canary/default-off injection path. It does not mean fleet/default-on enablement.
