### PR TITLE
[verified] Polish Ichor rollout simulation gate

### DIFF
--- a/scripts/simulate-ichor-context-pack-rollout.py
+++ b/scripts/simulate-ichor-context-pack-rollout.py
@@ -12,13 +12,17 @@ Safety boundary:
 - no session rotation
 - no transcript rewrite
 - no runtime DB writes
+
+The simulation validates source titles for prompt hygiene. Source paths are
+recorded raw in artifacts for provenance/debugging and are intentionally not
+render-sanitized here; the builder remains responsible for generating safe
+injectable prompt text.
 """
 from __future__ import annotations
 
 import argparse
 import json
 import sys
-import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -137,7 +141,6 @@ def simulate_case(case: SimulationCase, artifact_dir: Path) -> tuple[dict[str, A
     from lib.ichor.context_pack import build_context_pack
 
     artifact_dir.mkdir(parents=True, exist_ok=True)
-    started = time.perf_counter()
     before_messages = _base_messages(case)
     before_tokens = _estimate_messages_tokens(before_messages)
     pack = build_context_pack(
@@ -160,7 +163,6 @@ def simulate_case(case: SimulationCase, artifact_dir: Path) -> tuple[dict[str, A
         after_messages.insert(1, _context_message(injectable))
     after_tokens = _estimate_messages_tokens(after_messages)
     source_link_count = len(source_links)
-    wall_ms = int((time.perf_counter() - started) * 1000)
     source_quality_ok = source_link_count >= case.min_sources and _source_titles_clean(source_links)
     noop_clean = (
         not case.expected_injection
@@ -196,7 +198,7 @@ def simulate_case(case: SimulationCase, artifact_dir: Path) -> tuple[dict[str, A
         "db_writes": int(metrics.get("db_writes", 0) or 0),
         "llm_calls": int(metrics.get("llm_calls", 0) or 0),
         "api_calls": int(metrics.get("api_calls", 0) or 0),
-        "wall_ms": int(metrics.get("wall_ms", wall_ms) or wall_ms),
+        "wall_ms": int(metrics.get("wall_ms", 0) or 0),
         "would_mutate_runtime": False,
         "would_change_config": False,
         "would_restart_gateway": False,

--- a/tests/test_ichor_context_pack_rollout_simulation.py
+++ b/tests/test_ichor_context_pack_rollout_simulation.py
@@ -13,9 +13,15 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "simulate-ichor-context-pack-rollout.py"
+HAS_ROLLOUT_FIXTURE = (
+    (Path.home() / ".hermes" / "ichor.db").exists()
+    and Path("/home/konan/athenaeum").exists()
+)
 
 
 def load_module():
@@ -82,6 +88,10 @@ def test_noop_case_does_not_inject_or_read_memory(tmp_path: Path) -> None:
     assert row["tokens_estimated"] == 0
 
 
+@pytest.mark.skipif(
+    not HAS_ROLLOUT_FIXTURE,
+    reason="rollout simulation matrix requires local Ichor DB and Athenaeum anchors",
+)
 def test_cli_writes_rollout_simulation_artifacts_and_summary(tmp_path: Path) -> None:
     artifact_dir = tmp_path / "rollout-sim"
     proc = subprocess.run(


### PR DESCRIPTION
## Summary

Applies non-blocking reviewer polish from the rollout simulation review:

- documents that source paths are raw artifact provenance while source titles carry prompt-hygiene validation
- removes vestigial local wall-clock fallback in favor of builder metrics
- marks the full CLI matrix test as requiring local Ichor DB + Athenaeum fixtures, so CI hosts without those anchors skip explicitly instead of failing opaquely

## Test Plan

- `ast.parse` on both touched Python files
- `py_compile` on both touched Python files
- `pytest tests/test_ichor_context_pack_rollout_simulation.py tests/test_ichor_context_pack.py tests/test_ichor_context_pack_canary.py tests/test_ichor_mcp.py -q`
  - Result: `36 passed, 12 warnings in 5.02s`
- Live-safe simulation artifact:
  - `/tmp/ichor-context-pack-rollout-sim-followup-20260814T140027Z`
  - `rollout_sim_ready=true`
  - `all_no_llm_api=true`
  - `all_no_db_writes=true`
  - `noop_rows_clean=true`
