### PR TITLE
[verified] Add Ichor compressor-weight benchmark

### DIFF
--- a/docs/specs/ichor-compressor-weight-benchmark.md
+++ b/docs/specs/ichor-compressor-weight-benchmark.md
@@ -1,0 +1,42 @@
+# Ichor Compressor-Weight Benchmark — Spec Contract
+
+## Source handoff
+
+Original handoff: `~/athenaeum/Codex-Pantheon/design/ichor-context-pack-compressor-augmentation.md`.
+
+This work implements the missing Phase 0/2 measurement gate. It does **not** enable live context-pack injection, change `context.engine`, restart gateways, rotate sessions, or re-enable Hermes LCM.
+
+## Problem
+
+The existing replay and rollout-simulation gates prove that the Ichor context pack can add source-backed recall context safely. They do **not** prove compressor-weight behavior because their default-compressor baseline usually evaluates tiny prompts where `ContextCompressor.should_compress()` is false.
+
+The benchmark must exercise a long transcript where Hermes' built-in `ContextCompressor` really has a compressible middle window and then compare that baseline against Ichor context-pack augmentation metrics.
+
+## Acceptance gates
+
+For each benchmark case:
+
+1. Default compressor baseline is available.
+2. Long transcript estimated tokens exceed the compressor threshold.
+3. `ContextCompressor.has_content_to_compress(messages)` is true.
+4. The benchmark calls `ContextCompressor.compress(...)` on a copied fixture with a deterministic fake summary path, so no provider/API call is made.
+5. Default compression reduces token estimate and message count.
+6. Ichor context-pack build has `llm_calls == 0`, `api_calls == 0`, `db_writes == 0`.
+7. Ichor context pack stays within `max_pack_tokens`.
+8. Safety flags stay false: no runtime mutation, session rotation, transcript rewrite, config edit, or gateway restart.
+9. No-op benchmark row stays zero-read/zero-injection.
+10. Benchmark writes JSON summary + markdown report artifacts.
+
+## Compared modes
+
+- `default_compressor`: built-in `ContextCompressor.compress()` on a synthetic long transcript with deterministic fake summarization.
+- `ichor_context_pack`: current Ichor selector/pack builder.
+- `hybrid_projection`: default compressed context plus bounded Ichor pack token overhead; this is a measurement projection only, not live wiring.
+
+## Out of scope
+
+- Live profile canary.
+- New context engine plugin.
+- Fleet defaults.
+- Hermes LCM re-enable.
+- Real LLM/API compression calls.

--- a/docs/specs/ichor-precision-context-engine.md
+++ b/docs/specs/ichor-precision-context-engine.md
@@ -1,0 +1,289 @@
+# Ichor Precision Context Engine — Reference Design
+
+## Purpose
+
+The product goal is not to make lossy context compaction better. The goal is to make routine context compaction unnecessary by changing Hermes from an ever-growing live transcript into a bounded, memory-backed context selector.
+
+Current Hermes shape:
+
+```text
+append every turn to live messages
+→ live prompt grows
+→ hit threshold
+→ ContextCompressor summarizes/drops old middle
+→ keep sending large active context until the next compaction
+```
+
+Target Ichor shape:
+
+```text
+ingest every turn losslessly into Ichor
+→ maintain session frontier and fresh tail
+→ classify the current turn
+→ select only context needed for this turn
+→ expose exact recall/expand tools for anything omitted
+→ send a small source-backed prompt
+```
+
+This makes Ichor the memory substrate and `IchorContextEngine` the compressor-replacement surface. The `compress()` method still satisfies Hermes' `ContextEngine` interface, but internally it means **memory promotion plus bounded active-context assembly**, not lossy summarization.
+
+## Non-goals
+
+- Do not re-enable the separate Hermes-LCM plugin fleet-wide.
+- Do not keep injecting a static context pack forever.
+- Do not summarize raw truth into authority; summaries are derived views only.
+- Do not rely on large prompt windows as the primary memory strategy.
+- Do not mutate live profile/fleet config until default-off benchmarks prove the engine.
+
+## Operating invariants
+
+1. **Raw turns are authoritative.** Every user, assistant, tool-call, and tool-result message is stored losslessly with source metadata and content hashes.
+2. **Active prompt is bounded every turn.** The model should receive only the current request, a small fresh tail, active frontier state, and relevant selected memory.
+3. **No-op turns stay cheap.** If the current turn does not need stored context, inject nothing beyond the fresh tail and stable system/user rules.
+4. **Derived context is source-backed.** Decisions, constraints, files, and summaries point back to exact raw turns or canonical source files.
+5. **Exact expansion is available on demand.** Omitted context can be recalled by handle/source id via `ichor_recall`, `ichor_expand`, or `ichor_inspect`.
+6. **Fresh user intent wins.** Recent user instructions and current task state outrank older summaries or stale memory.
+7. **Fallback preserves safety.** If Ichor selection fails, preserve fresh tail and fall back to default compressor or unchanged messages according to configured mode.
+
+## Per-turn context assembly pipeline
+
+### 0. Inputs
+
+Each turn starts with:
+
+- full in-process message list supplied by Hermes
+- current user message
+- session id / platform thread id
+- tool schemas available to this session
+- token budget from model metadata
+- Ichor session frontier state
+
+### 1. Lossless turn ingestion
+
+Before selection, persist any new messages since the last frontier:
+
+```text
+raw_turns(session_id, seq, role, content_hash, content, source, tool_name, timestamps)
+raw_tool_results(session_id, seq, tool_call_id, tool_name, status, content_hash, content)
+```
+
+Cost control:
+
+- append-only writes
+- content hash dedupe for repeated tool output
+- store large tool results by blob reference, not repeatedly inline
+- batch writes once per turn, not per selector phase
+- avoid LLM extraction on the hot path
+
+### 2. Frontier update
+
+Maintain a compact session frontier:
+
+```text
+session_id
+last_ingested_seq
+active_tail_start_seq
+last_selected_context_ids
+current_task_id
+current_topic_hash
+fresh_tail_count
+turn_count_since_topic_shift
+```
+
+The frontier says what can be omitted from the live prompt because it is safely stored and recallable.
+
+### 3. Cheap current-turn classification
+
+Use deterministic first-pass classifiers before any semantic/vector work:
+
+- command shape: build / compare / summarize / debug / recall / casual
+- topic shift vs continuation
+- named entities: repo, branch, PR, file path, god, service, endpoint, artifact path
+- explicit references: “that”, “this”, “the benchmark”, “PR #138”, “continue”
+- safety-sensitive intent: config change, gateway restart, destructive op, credential work
+
+Cost control:
+
+- regex/path/entity extraction first
+- only use vector search when lexical/entity confidence is low
+- no LLM call for routine classification
+- cache classification result by current-message hash
+
+### 4. Candidate memory retrieval
+
+Build a candidate set from multiple cheap lanes, in priority order:
+
+1. **Pinned active state** — current todos, current branch/PR/artifact, latest user directive.
+2. **Fresh tail references** — entities mentioned in the last N turns.
+3. **Exact lexical matches** — file paths, PR ids, branch names, artifact names, service names.
+4. **Ichor facts/events/decisions** — source-backed facts scoped to the current task/god/project.
+5. **Vector/semantic recall** — only if lexical/entity lanes do not satisfy coverage.
+6. **Raw-turn handles** — include handles for expansion, not full raw text unless required.
+
+Cost control:
+
+- hard cap rows examined per lane
+- stop early when coverage is sufficient
+- prefer structured indexed rows over raw transcript scans
+- negative cache known no-op/casual queries
+- per-session hot cache for recently selected context ids
+
+### 5. Relevance scoring and pruning
+
+Score candidates with a cheap weighted model:
+
+```text
+score = recency
+      + explicit_reference_match
+      + entity_overlap
+      + active_task_match
+      + source_authority
+      + user_directive_priority
+      - stale_topic_penalty
+      - already_in_fresh_tail_penalty
+      - large_payload_penalty
+```
+
+Then prune by:
+
+- relevance threshold
+- token budget
+- diversity across categories: decisions, constraints, files, artifacts, risks
+- source freshness
+- contradiction handling: newer source-backed items outrank older summaries
+
+### 6. Assemble bounded prompt sections
+
+The engine returns a valid OpenAI-format message list containing:
+
+```text
+1. system/developer prompt layers already required by Hermes
+2. stable user profile / durable preferences
+3. current task frontier brief, if any
+4. fresh tail: small number of recent raw turns
+5. selected Ichor context pack: only relevant source-backed items
+6. exact recall handles for omitted-but-available context
+7. current user message
+```
+
+Recommended initial budgets:
+
+```text
+fresh_tail: 4–8 turns, dynamically reduced for tool-heavy sessions
+frontier_brief: <= 250 tokens
+selected_memory_pack: <= 600–900 tokens
+recall_handles: <= 150 tokens
+tool-result inline budget: <= 1,000 tokens unless current turn directly needs it
+```
+
+### 7. Exact expansion tools
+
+If the model lacks enough detail, it should call tools instead of receiving everything upfront:
+
+```text
+ichor_status(session_id)
+ichor_recall(query, scope, max_items)
+ichor_expand(source_id | raw_turn_range | artifact_id)
+ichor_inspect(frontier | selected_context | omitted_context)
+```
+
+The prompt should include handles like:
+
+```text
+Available expansions:
+- raw_turns:session:123:seq:80-94 — PR #138 benchmark build loop
+- artifact:/tmp/ichor-compressor-weight-benchmark-ready-reviewfix.../summary.json
+- decision:ichor-context-engine-target
+```
+
+not the full historical text.
+
+## Low-token strategy
+
+1. **Do not send stored history by default.** Store it, index it, and pass handles.
+2. **Use a small fresh tail.** Most turn coherence comes from the last few exchanges, not the full thread.
+3. **Summaries are optional views, not mandatory prompt cargo.** If a summary is not relevant to the current turn, omit it.
+4. **Prefer facts over prose.** A 40-token source-backed decision beats a 500-token paragraph.
+5. **Prefer handles over payloads.** Send `expand_id` unless exact text is immediately necessary.
+6. **Elide duplicated tool output.** If a tool result is already stored and not needed verbatim, include only status/hash/path.
+7. **No-op suppression.** Casual acknowledgements and broad planning pivots should not pull database context unless entities match.
+8. **Budget by category.** No single lane gets to consume the whole context window.
+
+## Low-resource strategy
+
+1. **Hot path is deterministic.** Regex/entity/path extraction and indexed lookup happen before vector or LLM work.
+2. **Use SQLite/FTS/entity indexes first.** Chroma/vector search is a fallback, not default per turn.
+3. **Batch writes.** One append transaction per turn.
+4. **Deduplicate blobs by content hash.** Large repeated tool outputs are stored once.
+5. **Cache selected packs.** Reuse when current-message/topic hash and frontier are unchanged.
+6. **Bound all loops.** Max rows examined, max source expansions, max wall time.
+7. **Degrade gracefully.** If retrieval exceeds budget, return fresh tail + handles, not a huge panic pack.
+8. **Async extraction.** Expensive entity/relationship extraction can happen after the response as background enrichment.
+
+## Minimal viable `IchorContextEngine`
+
+```text
+class IchorContextEngine(ContextEngine):
+    name = "ichor"
+
+    on_session_start:
+      load/create frontier
+
+    should_compress:
+      return True when live messages exceed active-tail budget OR frontier needs advancement
+
+    compress:
+      ingest new raw turns
+      classify current turn
+      retrieve/prune selected memory
+      assemble bounded messages
+      save frontier
+      return bounded OpenAI-format messages
+
+    get_tool_schemas:
+      expose ichor_status / ichor_recall / ichor_expand / ichor_inspect
+
+    handle_tool_call:
+      execute exact recall/expand against Ichor source records
+```
+
+## Benchmark acceptance for replacement
+
+The replacement benchmark must measure per-turn prompt economy, not only after-threshold compression.
+
+Compare:
+
+```text
+A: current Hermes transcript accumulation + default compressor
+B: Ichor context-pack sidecar
+C: IchorContextEngine selector
+D: hybrid fallback
+```
+
+Required metrics:
+
+- tokens sent per turn
+- cumulative tokens sent over a task
+- retained decision/constraint correctness
+- source-grounding rate
+- missed-context rate
+- stale-context injection rate
+- no-op injection rate
+- latency and rows examined
+- DB reads/writes
+- LLM/API calls
+- fallback behavior
+
+Win condition:
+
+```text
+IchorContextEngine sends materially fewer tokens per turn than default transcript accumulation while preserving or improving task correctness and source grounding.
+```
+
+## Rollout path
+
+1. Keep PR #138 as the augmentation/benchmark proof.
+2. Build `IchorContextEngine` default-off behind explicit config.
+3. Run per-turn token economy benchmark on long realistic sessions.
+4. Canary only one disposable profile after benchmark win.
+5. Promote to broader profiles only after rollback and no-op behavior are proven.

--- a/hermes-agent/hermes_constants.py
+++ b/hermes-agent/hermes_constants.py
@@ -51,6 +51,18 @@ def _get_platform_default_hermes_home() -> Path:
     return Path.home() / ".hermes"
 
 
+def _hermes_home_from_env() -> Path:
+    """Resolve HERMES_HOME from the process environment only.
+
+    This deliberately ignores the context-local override used for task/profile
+    scoping so dashboard/process-scoped callers can depend on the launch home.
+    """
+    val = os.environ.get("HERMES_HOME", "").strip()
+    if val:
+        return Path(val)
+    return _get_platform_default_hermes_home()
+
+
 def get_hermes_home() -> Path:
     """Return the Hermes home directory (default: platform-native path).
 
@@ -107,6 +119,16 @@ def get_hermes_home() -> Path:
                 pass
 
     return _get_platform_default_hermes_home()
+
+
+def get_process_hermes_home() -> Path:
+    """Return the Hermes home for the running process, ignoring task overrides.
+
+    Unlike ``get_hermes_home``, this never follows the context-local override
+    set by ``set_hermes_home_override``. It resolves only the process
+    ``HERMES_HOME`` env var, falling back to the platform-native default.
+    """
+    return _hermes_home_from_env()
 
 
 def get_default_hermes_root() -> Path:

--- a/hermes-agent/utils.py
+++ b/hermes-agent/utils.py
@@ -323,6 +323,17 @@ def env_int(key: str, default: int = 0) -> int:
         return default
 
 
+def env_float(key: str, default: float = 0.0) -> float:
+    """Read an environment variable as a float, with fallback."""
+    raw = os.getenv(key, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        return default
+
+
 def env_bool(key: str, default: bool = False) -> bool:
     """Read an environment variable as a boolean."""
     return is_truthy_value(os.getenv(key, ""), default=default)
@@ -438,3 +449,22 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     if not domain:
         return False
     return hostname == domain or hostname.endswith("." + domain)
+
+
+# ── Fast YAML loading ────────────────────────────────────────────────────
+_fast_yaml_loader = None
+
+
+def _get_fast_yaml_loader():
+    """Return the fastest safe PyYAML loader available."""
+    global _fast_yaml_loader
+    if _fast_yaml_loader is None:
+        _fast_yaml_loader = getattr(yaml, "CSafeLoader", None) or yaml.SafeLoader
+    return _fast_yaml_loader
+
+
+def fast_safe_load(stream: Any) -> Any:
+    """``yaml.safe_load`` using the libyaml C loader when available."""
+    # Safe: ``_get_fast_yaml_loader`` returns ``yaml.CSafeLoader`` or
+    # ``yaml.SafeLoader`` only, matching ``yaml.safe_load`` semantics.
+    return yaml.load(stream, Loader=_get_fast_yaml_loader())

--- a/scripts/benchmark-ichor-compressor-weight.py
+++ b/scripts/benchmark-ichor-compressor-weight.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""Offline compressor-weight benchmark for Ichor context packs.
+
+This is the missing Phase 0/2 gate from the original handoff: exercise Hermes'
+default ``ContextCompressor`` on synthetic long transcripts that actually cross
+its threshold, then compare the Ichor context-pack candidate as a bounded memory
+augmentation. The default compressor path uses a deterministic fake summary so
+this benchmark never calls an LLM provider or mutates runtime state.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from types import MethodType
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HERMES_AGENT = ROOT / "hermes-agent"
+if str(HERMES_AGENT) not in sys.path:
+    sys.path.insert(0, str(HERMES_AGENT))
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+MAX_PACK_TOKENS = 900
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    """One benchmark row for compressor-vs-Ichor measurement."""
+
+    case_id: str
+    god: str
+    phase: str
+    query: str
+    expect_injection: bool
+    min_sources: int
+    max_pack_tokens: int = MAX_PACK_TOKENS
+
+
+CASES: tuple[BenchmarkCase, ...] = (
+    BenchmarkCase(
+        "hermes-lcm-risk-long-thread",
+        "hermes",
+        "ops",
+        "LCM risk recall and Ichor compressor replacement",
+        True,
+        2,
+    ),
+    BenchmarkCase(
+        "thoth-lcm-risk-long-thread",
+        "thoth",
+        "research",
+        "LCM risk recall and Ichor context-pack compressor augmentation",
+        True,
+        2,
+    ),
+    BenchmarkCase(
+        "hephaestus-conductor-long-debug-thread",
+        "hephaestus",
+        "debug",
+        "Conductor v2",
+        True,
+        3,
+    ),
+    BenchmarkCase(
+        "rheta-pricing-long-copy-thread",
+        "rheta",
+        "copywriting",
+        "Pantheon pricing managed retainer dedicated infrastructure",
+        True,
+        2,
+    ),
+    BenchmarkCase(
+        "casual-long-noop",
+        "hermes",
+        "chat",
+        "random casual hello",
+        False,
+        0,
+    ),
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _default_artifact_dir() -> Path:
+    return Path("/tmp") / f"ichor-compressor-weight-benchmark-{_utc_stamp()}"
+
+
+def _rss_kb() -> int | None:
+    try:
+        for line in Path("/proc/self/status").read_text(encoding="utf-8").splitlines():
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1])
+    except (OSError, IndexError, ValueError):
+        return None
+    return None
+
+
+def _estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
+    try:
+        from agent.model_metadata import estimate_messages_tokens_rough
+    except Exception:
+        return sum((len(str(message.get("content", ""))) + 3) // 4 for message in messages)
+    return int(estimate_messages_tokens_rough(messages))
+
+
+def _estimate_text_tokens(text: str) -> int:
+    return (len(text) + 3) // 4 if text else 0
+
+
+def _long_content(case: BenchmarkCase, turn: int, role: str) -> str:
+    topic = case.query
+    repeated = (
+        f"{topic} | Ichor memory expansion | compressor-weight benchmark | "
+        f"source grounding | no LCM re-enable | turn {turn} | role {role}. "
+    )
+    if case.expect_injection:
+        anchor = (
+            "The durable constraint is that Ichor should provide LCM-like recall "
+            "by selecting source-backed memory while the default compressor remains "
+            "the baseline until benchmark proof exists. "
+        )
+    else:
+        anchor = (
+            "Casual filler for a long transcript that should compress normally, "
+            "but should not trigger Ichor memory selection for the current query. "
+        )
+    return (anchor + repeated) * 18
+
+
+def _make_long_transcript(case: BenchmarkCase, threshold_tokens: int) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "system",
+            "content": (
+                "Synthetic long transcript for the Ichor compressor-weight benchmark. "
+                "It is offline fixture data and carries no live runtime state."
+            ),
+        }
+    ]
+    turn = 0
+    while True:
+        turn += 1
+        messages.append({"role": "user", "content": _long_content(case, turn, "user")})
+        messages.append({"role": "assistant", "content": _long_content(case, turn, "assistant")})
+        if turn >= 42 and _estimate_messages_tokens(messages) > threshold_tokens + 12_000:
+            return messages
+        if turn >= 90:
+            return messages
+
+
+def _fake_summary(case: BenchmarkCase, call_counter: dict[str, int], _self: Any, turns: list[dict[str, Any]], focus_topic: str | None = None) -> str:
+    call_counter["llm_calls"] += 1
+    first = str(turns[0].get("content", ""))[:180] if turns else ""
+    last = str(turns[-1].get("content", ""))[:180] if turns else ""
+    return "\n".join(
+        [
+            "## Historical Task Snapshot",
+            f"Synthetic benchmark summary for {case.case_id}.",
+            f"Focus topic: {focus_topic or case.query}.",
+            f"Compressed turns: {len(turns)}.",
+            "## Key Decisions",
+            "- Preserve source-backed Ichor memory context without re-enabling LCM.",
+            "- Keep default compressor as measured baseline until benchmark gates pass.",
+            "## Evidence Samples",
+            f"- First compressed sample: {first}",
+            f"- Last compressed sample: {last}",
+        ]
+    )
+
+
+def _run_default_compressor(case: BenchmarkCase) -> dict[str, Any]:
+    started = time.perf_counter()
+    rss_before = _rss_kb()
+    try:
+        from agent.context_compressor import ContextCompressor
+    except Exception as exc:
+        return {
+            "available": False,
+            "error": str(exc),
+            "api_calls": 0,
+            "llm_calls": 0,
+            "called_compress_method": False,
+        }
+
+    compressor = ContextCompressor(
+        model="compressor-weight-benchmark",
+        quiet_mode=True,
+        config_context_length=128_000,
+    )
+    messages = _make_long_transcript(case, compressor.threshold_tokens)
+    tokens_before = _estimate_messages_tokens(messages)
+    call_counter = {"llm_calls": 0}
+
+    def bound_fake_summary(self: Any, turns: list[dict[str, Any]], focus_topic: str | None = None) -> str:
+        return _fake_summary(case, call_counter, self, turns, focus_topic)
+
+    compressor._generate_summary = MethodType(bound_fake_summary, compressor)  # type: ignore[attr-defined]
+    would_compress = bool(compressor.should_compress(tokens_before))
+    has_window = bool(compressor.has_content_to_compress(messages))
+    compressed = compressor.compress(copy.deepcopy(messages), current_tokens=tokens_before, force=True)
+    tokens_after = _estimate_messages_tokens(compressed)
+    rss_after = _rss_kb()
+    return {
+        "available": True,
+        "engine": compressor.name,
+        "threshold_tokens": compressor.threshold_tokens,
+        "tail_token_budget": compressor.tail_token_budget,
+        "tokens_before": tokens_before,
+        "tokens_after": tokens_after,
+        "tokens_saved": tokens_before - tokens_after,
+        "message_count_before": len(messages),
+        "message_count_after": len(compressed),
+        "would_compress_by_threshold": would_compress,
+        "has_compressible_window": has_window,
+        "called_compress_method": True,
+        "compression_count": compressor.compression_count,
+        "summary_fallback_used": bool(getattr(compressor, "_last_summary_fallback_used", False)),
+        "summary_dropped_count": int(getattr(compressor, "_last_summary_dropped_count", 0) or 0),
+        "llm_calls": int(call_counter["llm_calls"]),
+        "api_calls": 0,
+        "wall_ms": int((time.perf_counter() - started) * 1000),
+        "rss_delta_kb": None if rss_before is None or rss_after is None else rss_after - rss_before,
+    }
+
+
+def _run_ichor_context_pack(case: BenchmarkCase) -> dict[str, Any]:
+    started = time.perf_counter()
+    from lib.ichor.context_pack import build_context_pack
+
+    pack = build_context_pack(
+        case.query,
+        god_name=case.god,
+        phase=case.phase,
+        max_items=8,
+        max_tokens=case.max_pack_tokens,
+        max_ms=350,
+        include_graph=True,
+        dry_run=True,
+    )
+    coverage = pack.get("coverage", {})
+    metrics = pack.get("metrics", {})
+    source_links = pack.get("source_links", []) or []
+    injectable = str(pack.get("injectable_context", "") or "")
+    return {
+        "coverage_status": coverage.get("status"),
+        "returned": int(coverage.get("returned", 0) or 0),
+        "omitted": int(coverage.get("omitted", 0) or 0),
+        "warnings": list(coverage.get("warnings", []) or []) + list(pack.get("warnings", []) or []),
+        "injected": bool(injectable),
+        "injectable_context_length": len(injectable),
+        "source_link_count": len(source_links),
+        "source_titles": [str(link.get("title", "")) for link in source_links],
+        "source_paths": [str(link.get("source_path", "")) for link in source_links],
+        "tokens_estimated": int(metrics.get("tokens_estimated", 0) or 0),
+        "db_reads": int(metrics.get("db_reads", 0) or 0),
+        "db_writes": int(metrics.get("db_writes", 0) or 0),
+        "rows_examined": int(metrics.get("rows_examined", 0) or 0),
+        "llm_calls": int(metrics.get("llm_calls", 0) or 0),
+        "api_calls": int(metrics.get("api_calls", 0) or 0),
+        "wall_ms": int(metrics.get("wall_ms", int((time.perf_counter() - started) * 1000)) or 0),
+        "rss_delta_kb": metrics.get("rss_delta_kb"),
+        "pack": pack,
+    }
+
+
+def run_case(case: BenchmarkCase, artifact_dir: Path) -> tuple[dict[str, Any], Path]:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    default = _run_default_compressor(case)
+    candidate = _run_ichor_context_pack(case)
+    no_mutation_flags = {
+        "would_mutate_runtime": False,
+        "would_rotate_session": False,
+        "would_rewrite_transcript": False,
+        "would_change_config": False,
+        "would_restart_gateway": False,
+    }
+
+    default_ok = (
+        bool(default.get("available"))
+        and bool(default.get("would_compress_by_threshold"))
+        and bool(default.get("has_compressible_window"))
+        and bool(default.get("called_compress_method"))
+        and int(default.get("api_calls", 0) or 0) == 0
+        and int(default.get("llm_calls", 0) or 0) == 1
+        and int(default.get("tokens_after", 0) or 0) < int(default.get("tokens_before", 0) or 0)
+        and int(default.get("message_count_after", 0) or 0) < int(default.get("message_count_before", 0) or 0)
+    )
+    if case.expect_injection:
+        candidate_quality_ok = (
+            candidate["injected"]
+            and candidate["source_link_count"] >= case.min_sources
+            and candidate["coverage_status"] == "ok"
+        )
+    else:
+        candidate_quality_ok = (
+            not candidate["injected"]
+            and candidate["source_link_count"] == 0
+            and candidate["db_reads"] == 0
+            and candidate["tokens_estimated"] == 0
+        )
+    candidate_safety_ok = (
+        candidate["llm_calls"] == 0
+        and candidate["api_calls"] == 0
+        and candidate["db_writes"] == 0
+        and candidate["tokens_estimated"] <= case.max_pack_tokens
+    )
+
+    tokens_after = int(default.get("tokens_after", 0) or 0)
+    pack_tokens = int(candidate["tokens_estimated"] or 0)
+    hybrid_tokens = tokens_after + pack_tokens
+    row = {
+        "case_id": case.case_id,
+        "god": case.god,
+        "phase": case.phase,
+        "query": case.query,
+        "expect_injection": case.expect_injection,
+        "min_sources": case.min_sources,
+        "max_pack_tokens": case.max_pack_tokens,
+        "default_compressor": default,
+        "ichor_context_pack": {k: v for k, v in candidate.items() if k != "pack"},
+        "hybrid_projection": {
+            "tokens_after_default_plus_pack": hybrid_tokens,
+            "pack_overhead_tokens": pack_tokens,
+            "pack_overhead_pct_of_default_after": round((pack_tokens / tokens_after * 100), 2) if tokens_after else None,
+            "would_rewrite_static_prefix": False,
+        },
+        "default_ok": default_ok,
+        "candidate_quality_ok": candidate_quality_ok,
+        "candidate_safety_ok": candidate_safety_ok,
+        "row_ready": default_ok and candidate_quality_ok and candidate_safety_ok,
+        **no_mutation_flags,
+    }
+    case_path = artifact_dir / f"{case.case_id}.json"
+    case_path.write_text(json.dumps({"row": row, "pack": candidate["pack"]}, indent=2, sort_keys=True), encoding="utf-8")
+    return row, case_path
+
+
+def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    positive_rows = [row for row in rows if row["expect_injection"]]
+    noop_rows = [row for row in rows if not row["expect_injection"]]
+    default_exercised = [
+        row for row in rows
+        if row["default_compressor"].get("called_compress_method")
+        and row["default_compressor"].get("has_compressible_window")
+        and row["default_compressor"].get("would_compress_by_threshold")
+    ]
+    all_default_rows_reduced_tokens = all(
+        int(row["default_compressor"].get("tokens_after", 0) or 0)
+        < int(row["default_compressor"].get("tokens_before", 0) or 0)
+        for row in rows
+    )
+    all_no_runtime_mutation = all(
+        not row["would_mutate_runtime"]
+        and not row["would_rotate_session"]
+        and not row["would_rewrite_transcript"]
+        and not row["would_change_config"]
+        and not row["would_restart_gateway"]
+        for row in rows
+    )
+    all_candidate_no_llm_api = all(
+        row["ichor_context_pack"]["llm_calls"] == 0
+        and row["ichor_context_pack"]["api_calls"] == 0
+        for row in rows
+    )
+    all_candidate_no_db_writes = all(row["ichor_context_pack"]["db_writes"] == 0 for row in rows)
+    all_pack_tokens_bounded = all(
+        row["ichor_context_pack"]["tokens_estimated"] <= row["max_pack_tokens"]
+        for row in rows
+    )
+    positive_rows_source_backed = all(
+        row["ichor_context_pack"]["source_link_count"] >= row["min_sources"]
+        and row["ichor_context_pack"]["injected"]
+        for row in positive_rows
+    )
+    noop_rows_clean = all(
+        not row["ichor_context_pack"]["injected"]
+        and row["ichor_context_pack"]["db_reads"] == 0
+        and row["ichor_context_pack"]["tokens_estimated"] == 0
+        for row in noop_rows
+    )
+    row_ready_all = all(row["row_ready"] for row in rows)
+    blockers: list[str] = []
+    if len(default_exercised) < len(positive_rows):
+        blockers.append("default_compressor_not_exercised_on_positive_rows")
+    if not all_default_rows_reduced_tokens:
+        blockers.append("default_compressor_did_not_reduce_tokens")
+    if not all_no_runtime_mutation:
+        blockers.append("runtime_mutation_flag_set")
+    if not all_candidate_no_llm_api:
+        blockers.append("candidate_used_llm_or_api")
+    if not all_candidate_no_db_writes:
+        blockers.append("candidate_wrote_db")
+    if not all_pack_tokens_bounded:
+        blockers.append("candidate_pack_exceeded_token_budget")
+    if not positive_rows_source_backed:
+        blockers.append("positive_rows_not_source_backed")
+    if not noop_rows_clean:
+        blockers.append("noop_rows_not_clean")
+    if not row_ready_all:
+        blockers.append("one_or_more_rows_not_ready")
+
+    return {
+        "rows_run": len(rows),
+        "positive_rows": len(positive_rows),
+        "noop_rows": len(noop_rows),
+        "default_compressor_exercised_rows": len(default_exercised),
+        "all_default_rows_reduced_tokens": all_default_rows_reduced_tokens,
+        "all_no_runtime_mutation": all_no_runtime_mutation,
+        "all_candidate_no_llm_api": all_candidate_no_llm_api,
+        "all_candidate_no_db_writes": all_candidate_no_db_writes,
+        "all_pack_tokens_bounded": all_pack_tokens_bounded,
+        "positive_rows_source_backed": positive_rows_source_backed,
+        "noop_rows_clean": noop_rows_clean,
+        "max_default_wall_ms": max((int(row["default_compressor"].get("wall_ms", 0) or 0) for row in rows), default=0),
+        "max_candidate_wall_ms": max((int(row["ichor_context_pack"].get("wall_ms", 0) or 0) for row in rows), default=0),
+        "max_candidate_tokens": max((int(row["ichor_context_pack"].get("tokens_estimated", 0) or 0) for row in rows), default=0),
+        "total_candidate_db_reads": sum(int(row["ichor_context_pack"].get("db_reads", 0) or 0) for row in rows),
+        "total_candidate_db_writes": sum(int(row["ichor_context_pack"].get("db_writes", 0) or 0) for row in rows),
+        "blockers": blockers,
+        "benchmark_ready": not blockers,
+    }
+
+
+def _format_report(payload: dict[str, Any]) -> str:
+    summary = payload["summary"]
+    lines = [
+        "# Ichor Compressor-Weight Benchmark",
+        "",
+        f"mode: {payload['mode']}",
+        f"benchmark_ready: {str(summary['benchmark_ready']).lower()}",
+        f"rows_run: {summary['rows_run']}",
+        f"default_compressor_exercised_rows: {summary['default_compressor_exercised_rows']}",
+        f"all_default_rows_reduced_tokens: {str(summary['all_default_rows_reduced_tokens']).lower()}",
+        f"all_candidate_no_llm_api: {str(summary['all_candidate_no_llm_api']).lower()}",
+        f"all_candidate_no_db_writes: {str(summary['all_candidate_no_db_writes']).lower()}",
+        f"noop_rows_clean: {str(summary['noop_rows_clean']).lower()}",
+        f"max_candidate_tokens: {summary['max_candidate_tokens']}",
+        "",
+        "## Rows",
+    ]
+    for row in payload["rows"]:
+        default = row["default_compressor"]
+        candidate = row["ichor_context_pack"]
+        lines.extend(
+            [
+                f"### {row['case_id']}",
+                f"row_ready: {str(row['row_ready']).lower()}",
+                (
+                    "default: "
+                    f"{default.get('tokens_before')} → {default.get('tokens_after')} tokens, "
+                    f"messages {default.get('message_count_before')} → {default.get('message_count_after')}, "
+                    f"llm_calls={default.get('llm_calls')} api_calls={default.get('api_calls')}"
+                ),
+                (
+                    "ichor: "
+                    f"injected={str(candidate.get('injected')).lower()} "
+                    f"sources={candidate.get('source_link_count')} "
+                    f"tokens={candidate.get('tokens_estimated')} "
+                    f"db_reads={candidate.get('db_reads')}"
+                ),
+                "",
+            ]
+        )
+    if summary["blockers"]:
+        lines.extend(["## Blockers", *[f"- {blocker}" for blocker in summary["blockers"]]])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def run_benchmark(artifact_dir: Path) -> dict[str, Any]:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+    case_paths: list[str] = []
+    for case in CASES:
+        row, case_path = run_case(case, artifact_dir)
+        rows.append(row)
+        case_paths.append(str(case_path))
+    summary = _summarize(rows)
+    payload = {
+        "mode": "compressor_weight_benchmark",
+        "artifact_dir": str(artifact_dir),
+        "would_mutate_runtime": False,
+        "would_rotate_session": False,
+        "would_rewrite_transcript": False,
+        "would_change_config": False,
+        "would_restart_gateway": False,
+        "summary": summary,
+        "rows": rows,
+        "case_paths": case_paths,
+    }
+    summary_path = artifact_dir / "summary.json"
+    report_path = artifact_dir / "BENCHMARK.md"
+    payload["summary_path"] = str(summary_path)
+    payload["report_path"] = str(report_path)
+    summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    report_path.write_text(_format_report(payload), encoding="utf-8")
+    return payload
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-dir", type=Path, default=None)
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    payload = run_benchmark(args.artifact_dir or _default_artifact_dir())
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_report(payload), end="")
+    return 0 if payload["summary"]["benchmark_ready"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark-ichor-compressor-weight.py
+++ b/scripts/benchmark-ichor-compressor-weight.py
@@ -96,6 +96,16 @@ def _default_artifact_dir() -> Path:
     return Path("/tmp") / f"ichor-compressor-weight-benchmark-{_utc_stamp()}"
 
 
+def _ensure_private_artifact_dir(artifact_dir: Path) -> None:
+    """Create artifact directory with owner-only permissions.
+
+    Case JSON artifacts include internal source paths/titles. Keep the benchmark
+    dry-run, but avoid making that metadata world-readable under shared /tmp.
+    """
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_dir.chmod(0o700)
+
+
 def _rss_kb() -> int | None:
     try:
         for line in Path("/proc/self/status").read_text(encoding="utf-8").splitlines():
@@ -234,20 +244,50 @@ def _run_default_compressor(case: BenchmarkCase) -> dict[str, Any]:
     }
 
 
+def _failed_ichor_pack(error: str, started: float) -> dict[str, Any]:
+    """Return a fail-closed candidate row when Ichor pack generation is unavailable."""
+    return {
+        "coverage_status": "error",
+        "returned": 0,
+        "omitted": 0,
+        "warnings": [error],
+        "injected": False,
+        "injectable_context_length": 0,
+        "source_link_count": 0,
+        "source_titles": [],
+        "source_paths": [],
+        "tokens_estimated": 0,
+        "db_reads": 0,
+        "db_writes": 0,
+        "rows_examined": 0,
+        "llm_calls": 0,
+        "api_calls": 0,
+        "wall_ms": int((time.perf_counter() - started) * 1000),
+        "rss_delta_kb": None,
+        "pack": {"error": error},
+    }
+
+
 def _run_ichor_context_pack(case: BenchmarkCase) -> dict[str, Any]:
     started = time.perf_counter()
-    from lib.ichor.context_pack import build_context_pack
+    try:
+        from lib.ichor.context_pack import build_context_pack
+    except Exception as exc:
+        return _failed_ichor_pack(f"context_pack_import_failed: {exc}", started)
 
-    pack = build_context_pack(
-        case.query,
-        god_name=case.god,
-        phase=case.phase,
-        max_items=8,
-        max_tokens=case.max_pack_tokens,
-        max_ms=350,
-        include_graph=True,
-        dry_run=True,
-    )
+    try:
+        pack = build_context_pack(
+            case.query,
+            god_name=case.god,
+            phase=case.phase,
+            max_items=8,
+            max_tokens=case.max_pack_tokens,
+            max_ms=350,
+            include_graph=True,
+            dry_run=True,
+        )
+    except Exception as exc:
+        return _failed_ichor_pack(f"context_pack_build_failed: {exc}", started)
     coverage = pack.get("coverage", {})
     metrics = pack.get("metrics", {})
     source_links = pack.get("source_links", []) or []
@@ -275,7 +315,7 @@ def _run_ichor_context_pack(case: BenchmarkCase) -> dict[str, Any]:
 
 
 def run_case(case: BenchmarkCase, artifact_dir: Path) -> tuple[dict[str, Any], Path]:
-    artifact_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_private_artifact_dir(artifact_dir)
     default = _run_default_compressor(case)
     candidate = _run_ichor_context_pack(case)
     no_mutation_flags = {

--- a/tests/test_ichor_compressor_weight_benchmark.py
+++ b/tests/test_ichor_compressor_weight_benchmark.py
@@ -5,11 +5,13 @@ exercised on long transcripts, not merely threshold-probed on tiny replay rows.
 """
 from __future__ import annotations
 
+import builtins
 import importlib.util
 import json
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -125,3 +127,39 @@ def test_cli_writes_benchmark_artifacts_and_summary(tmp_path: Path) -> None:
     assert Path(payload["summary_path"]).exists()
     assert Path(payload["report_path"]).exists()
     assert len(payload["case_paths"]) == summary["rows_run"]
+    assert artifact_dir.stat().st_mode & 0o777 == 0o700
+
+
+def test_ichor_pack_import_failure_is_reported_as_failing_row(tmp_path: Path) -> None:
+    module = load_module()
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "lib.ichor.context_pack":
+            raise ImportError("synthetic context-pack import miss")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        row, artifact = module.run_case(
+            module.BenchmarkCase(
+                case_id="hermes-lcm-risk-long-thread",
+                god="hermes",
+                phase="ops",
+                query="LCM risk recall and Ichor compressor replacement",
+                expect_injection=True,
+                min_sources=2,
+            ),
+            tmp_path,
+        )
+
+    assert artifact.exists()
+    candidate = row["ichor_context_pack"]
+    assert candidate["coverage_status"] == "error"
+    assert candidate["injected"] is False
+    assert candidate["llm_calls"] == 0
+    assert candidate["api_calls"] == 0
+    assert candidate["db_writes"] == 0
+    assert any("context_pack_import_failed" in warning for warning in candidate["warnings"])
+    assert row["candidate_quality_ok"] is False
+    assert row["candidate_safety_ok"] is True
+    assert row["row_ready"] is False

--- a/tests/test_ichor_compressor_weight_benchmark.py
+++ b/tests/test_ichor_compressor_weight_benchmark.py
@@ -1,0 +1,127 @@
+"""Tests for the real compressor-weight benchmark gate.
+
+These assert the handoff's missing measurement: default ContextCompressor must be
+exercised on long transcripts, not merely threshold-probed on tiny replay rows.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "benchmark-ichor-compressor-weight.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("benchmark_ichor_compressor_weight", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_benchmark_case_exercises_default_compressor_without_api_calls(tmp_path: Path) -> None:
+    module = load_module()
+
+    row, artifact = module.run_case(
+        module.BenchmarkCase(
+            case_id="hermes-lcm-risk-long-thread",
+            god="hermes",
+            phase="ops",
+            query="LCM risk recall and Ichor compressor replacement",
+            expect_injection=True,
+            min_sources=2,
+        ),
+        tmp_path,
+    )
+
+    assert artifact.exists()
+    baseline = row["default_compressor"]
+    assert baseline["available"] is True
+    assert baseline["would_compress_by_threshold"] is True
+    assert baseline["has_compressible_window"] is True
+    assert baseline["called_compress_method"] is True
+    assert baseline["api_calls"] == 0
+    assert baseline["llm_calls"] == 1
+    assert baseline["tokens_after"] < baseline["tokens_before"]
+    assert baseline["message_count_after"] < baseline["message_count_before"]
+
+    candidate = row["ichor_context_pack"]
+    assert candidate["injected"] is True
+    assert candidate["source_link_count"] >= 2
+    assert candidate["llm_calls"] == 0
+    assert candidate["api_calls"] == 0
+    assert candidate["db_writes"] == 0
+    assert candidate["tokens_estimated"] <= row["max_pack_tokens"]
+
+    assert row["would_mutate_runtime"] is False
+    assert row["would_rotate_session"] is False
+    assert row["would_rewrite_transcript"] is False
+    assert row["would_change_config"] is False
+    assert row["would_restart_gateway"] is False
+    assert row["row_ready"] is True
+
+
+def test_noop_case_stays_zero_read_zero_injection(tmp_path: Path) -> None:
+    module = load_module()
+
+    row, artifact = module.run_case(
+        module.BenchmarkCase(
+            case_id="casual-long-noop",
+            god="hermes",
+            phase="chat",
+            query="random casual hello",
+            expect_injection=False,
+            min_sources=0,
+        ),
+        tmp_path,
+    )
+
+    assert artifact.exists()
+    candidate = row["ichor_context_pack"]
+    assert candidate["injected"] is False
+    assert candidate["source_link_count"] == 0
+    assert candidate["db_reads"] == 0
+    assert candidate["tokens_estimated"] == 0
+    assert row["row_ready"] is True
+
+
+def test_cli_writes_benchmark_artifacts_and_summary(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "benchmark"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--format",
+            "json",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = json.loads(proc.stdout)
+    summary = payload["summary"]
+
+    assert payload["mode"] == "compressor_weight_benchmark"
+    assert payload["would_mutate_runtime"] is False
+    assert summary["rows_run"] >= 4
+    assert summary["benchmark_ready"] is True
+    assert summary["default_compressor_exercised_rows"] >= 3
+    assert summary["all_default_rows_reduced_tokens"] is True
+    assert summary["all_no_runtime_mutation"] is True
+    assert summary["all_candidate_no_llm_api"] is True
+    assert summary["all_candidate_no_db_writes"] is True
+    assert summary["noop_rows_clean"] is True
+    assert summary["blockers"] == []
+    assert Path(payload["summary_path"]).exists()
+    assert Path(payload["report_path"]).exists()
+    assert len(payload["case_paths"]) == summary["rows_run"]


### PR DESCRIPTION
## Summary

Builds the missing Phase 0/2 compressor-weight benchmark gate from the original Ichor context-pack handoff.

This PR adds:

- `docs/specs/ichor-compressor-weight-benchmark.md` — concise Spec Contract tying the benchmark to the handoff gates.
- `scripts/benchmark-ichor-compressor-weight.py` — offline benchmark harness that exercises Hermes `ContextCompressor.compress()` on synthetic long transcripts using a deterministic fake summary path, then compares bounded Ichor context-pack metrics.
- `tests/test_ichor_compressor_weight_benchmark.py` — RED/GREEN coverage proving the default compressor is actually exercised and Ichor remains no-LLM/no-write/dry-run.
- `docs/specs/ichor-precision-context-engine.md` — reference design for replacing routine context compaction with per-turn precision context selection.
- Vendored Hermes compatibility shims required to import the default compressor against the installed `hermes_cli` package: `get_process_hermes_home`, `fast_safe_load`, and `env_float`.

No live profile config changes, no gateway restarts, no session rotation, no transcript rewriting, and no LCM enablement.

## Verification

- RED gate first: `tests/test_ichor_compressor_weight_benchmark.py` failed with missing benchmark script.
- `PYTHONPATH=/tmp/pantheon-ichor-compressor-benchmark:/tmp/pantheon-ichor-compressor-benchmark/hermes-agent /usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/test_ichor_compressor_weight_benchmark.py -q` → `4 passed`.
- `PYTHONPATH=/tmp/pantheon-ichor-compressor-benchmark:/tmp/pantheon-ichor-compressor-benchmark/hermes-agent /usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/test_ichor_context_pack.py tests/test_ichor_context_pack_canary.py tests/test_ichor_context_pack_rollout_simulation.py tests/test_ichor_compressor_weight_benchmark.py -q` → `28 passed`.
- `PYTHONPATH=/tmp/pantheon-ichor-compressor-benchmark:/tmp/pantheon-ichor-compressor-benchmark/hermes-agent /usr/local/lib/hermes-agent/venv/bin/python -m py_compile scripts/benchmark-ichor-compressor-weight.py tests/test_ichor_compressor_weight_benchmark.py hermes-agent/hermes_constants.py hermes-agent/utils.py` → pass.
- `git diff --check` → pass.
- Static scan: no top-level debug `print()`, no bare `except:`, no hardcoded secrets.
- Benchmark artifact: `/tmp/ichor-compressor-weight-benchmark-ready-reviewfix-20260814T145924Z/summary.json`.

Benchmark verdict:

```json
{
  "benchmark_ready": true,
  "rows_run": 5,
  "default_compressor_exercised_rows": 5,
  "all_default_rows_reduced_tokens": true,
  "all_candidate_no_llm_api": true,
  "all_candidate_no_db_writes": true,
  "noop_rows_clean": true,
  "max_candidate_tokens": 399,
  "blockers": []
}
```
