### PR TITLE
[verified] Add default-off Ichor context engine prototype

### DIFF
--- a/docs/fusion/ichor-context-engine-remaining-build.md
+++ b/docs/fusion/ichor-context-engine-remaining-build.md
@@ -1,0 +1,104 @@
+# Fusion Spec Contract — IchorContextEngine Remaining Build
+
+## Objective
+
+Finish the remaining default-off `IchorContextEngine` build item: persist raw turns losslessly into an Ichor-owned SQLite store while preserving the v0 safety boundary.
+
+The current prototype keeps raw turns in process memory. That proves exact expansion handles inside one engine instance, but does not yet satisfy the architecture line from `docs/specs/ichor-precision-context-engine.md`:
+
+```text
+ingest every turn losslessly into Ichor
+→ maintain session frontier and fresh tail
+→ expose exact recall/expand tools for omitted context
+```
+
+## Files allowed
+
+Allowed to create/modify only:
+
+- `docs/fusion/ichor-context-engine-remaining-build.md`
+- `lib/ichor/raw_turns.py`
+- `hermes-agent/plugins/context_engine/ichor/__init__.py`
+- `tests/test_ichor_raw_turns.py`
+- `tests/test_ichor_context_engine.py`
+
+Do not touch live config, profile env, cron, gateway units, LCM plugin settings, or PR #138 benchmark files unless a test proves it is required.
+
+## Interfaces
+
+Create `lib.ichor.raw_turns` with:
+
+```python
+@dataclass(frozen=True)
+class RawTurn:
+    session_id: str
+    seq: int
+    role: str
+    content: str
+    content_hash: str
+    message_json: str
+    tool_name: str | None = None
+    tool_call_id: str | None = None
+    source: str = "context_engine"
+    created_at: str | None = None
+
+class RawTurnStore:
+    def __init__(self, db_path: str | Path) -> None: ...
+    def migrate(self) -> dict[str, object]: ...
+    def ingest_messages(self, session_id: str, messages: list[dict[str, Any]], *, source: str = "context_engine") -> dict[str, int]: ...
+    def fetch_range(self, session_id: str, start_seq: int, end_seq: int) -> list[RawTurn]: ...
+    def get_frontier(self, session_id: str) -> dict[str, Any] | None: ...
+```
+
+SQLite tables:
+
+```sql
+ichor_raw_turns(session_id, seq, role, content_hash, content, message_json, tool_name, tool_call_id, source, created_at, PRIMARY KEY(session_id, seq))
+ichor_session_frontier(session_id PRIMARY KEY, last_ingested_seq, active_tail_start_seq, updated_at)
+```
+
+`ingest_messages()` must be idempotent by `(session_id, seq)` and must not duplicate repeated calls with the same message list.
+
+Update `IchorContextEngine`:
+
+- accepts optional `raw_turn_store: RawTurnStore | None`
+- default remains `None` so the prototype does not mutate live DB by default
+- `_ingest_raw_turns()` always keeps in-process rows and also writes to `raw_turn_store` if configured
+- `ichor_expand` first checks in-process rows, then falls back to `raw_turn_store.fetch_range()` if available
+- `get_status()` exposes raw-turn storage metrics: configured/persisted count/frontier or last error
+- no LLM/API calls; no fleet/profile/default changes
+
+## Constraints
+
+- Strict TDD: write tests that fail before implementation.
+- No top-level debug `print()` in Python files.
+- No bare `except:`.
+- No live DB writes in tests; use temp DB paths only.
+- No config/fleet/LCM changes.
+- Preserve existing benchmark verdict shape unless new storage metrics are additive.
+- If SQLite write fails, fail quiet for prompt assembly: keep in-process expansion working and report error in status; do not inject panic context into the live prompt.
+
+## Verification
+
+Commands must pass from `/tmp/pantheon-ichor-context-engine`:
+
+```bash
+PYTHONPATH=/tmp/pantheon-ichor-context-engine:/tmp/pantheon-ichor-context-engine/hermes-agent /usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/test_ichor_raw_turns.py tests/test_ichor_context_engine.py -q
+PYTHONPATH=/tmp/pantheon-ichor-context-engine:/tmp/pantheon-ichor-context-engine/hermes-agent /usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/test_ichor_context_pack.py tests/test_ichor_context_pack_canary.py tests/test_ichor_context_pack_rollout_simulation.py tests/test_ichor_compressor_weight_benchmark.py tests/test_ichor_context_engine.py tests/test_ichor_context_engine_turn_benchmark.py tests/test_ichor_raw_turns.py -q
+PYTHONPATH=/tmp/pantheon-ichor-context-engine:/tmp/pantheon-ichor-context-engine/hermes-agent /usr/local/lib/hermes-agent/venv/bin/python -m py_compile lib/ichor/raw_turns.py hermes-agent/plugins/context_engine/ichor/__init__.py tests/test_ichor_raw_turns.py tests/test_ichor_context_engine.py
+git diff --check
+```
+
+Also run a static scan for:
+
+- top-level `print(` outside `if __name__ == "__main__"`
+- bare `except:`
+- hardcoded token/API-key patterns
+
+## Expected result
+
+A stacked follow-up on PR #139 proving the remaining build item:
+
+```text
+IchorContextEngine can persist raw turns losslessly to Ichor when explicitly configured, while default-off operation still performs zero live DB writes.
+```

--- a/hermes-agent/plugins/context_engine/ichor/__init__.py
+++ b/hermes-agent/plugins/context_engine/ichor/__init__.py
@@ -72,6 +72,7 @@ class IchorContextEngine(ContextEngine):
         max_pack_tokens: int = 900,
         max_pack_items: int = 8,
         max_pack_ms: int = 120,
+        max_expand_chars: int = 12_000,
         context_length: int = 128_000,
         threshold_percent: float = 0.50,
     ) -> None:
@@ -79,6 +80,7 @@ class IchorContextEngine(ContextEngine):
         self.max_pack_tokens = max(1, int(max_pack_tokens))
         self.max_pack_items = max(1, int(max_pack_items))
         self.max_pack_ms = max(1, int(max_pack_ms))
+        self.max_expand_chars = max(1_000, int(max_expand_chars))
         self.threshold_percent = threshold_percent
         self.context_length = int(context_length)
         self.threshold_tokens = int(self.context_length * self.threshold_percent)
@@ -96,7 +98,7 @@ class IchorContextEngine(ContextEngine):
         self._last_injected = False
 
     def is_available(self) -> bool:
-        return True
+        return build_context_pack is not None
 
     def update_model(
         self,
@@ -108,7 +110,8 @@ class IchorContextEngine(ContextEngine):
         api_mode: str = "",
     ) -> None:
         del model, base_url, api_key, provider, api_mode
-        self.context_length = int(context_length or self.context_length)
+        if context_length is not None:
+            self.context_length = int(context_length)
         self.threshold_tokens = int(self.context_length * self.threshold_percent)
 
     def update_from_response(self, usage: dict[str, Any]) -> None:
@@ -147,6 +150,10 @@ class IchorContextEngine(ContextEngine):
         focus_topic: str = None,
         force: bool = False,
     ) -> list[dict[str, Any]]:
+        # `force` is accepted for ContextCompressor compatibility. Ichor v0 is
+        # always a bounded selector: it drops pre-tail prompt cargo from the
+        # returned live message list while retaining exact raw turns for
+        # expansion handles. It does not mean lossy summarization.
         del force
         session_id = self.session_id or "ichor-session"
         self._ingest_raw_turns(session_id, messages)
@@ -262,6 +269,8 @@ class IchorContextEngine(ContextEngine):
         )
 
     def _needs_context(self, query: str) -> bool:
+        if build_context_pack is None:
+            return False
         lowered = (query or "").lower()
         explicit_markers = (
             "ichor",
@@ -275,7 +284,7 @@ class IchorContextEngine(ContextEngine):
         if any(marker in lowered for marker in explicit_markers):
             return True
         if _needs_memory_context is None:
-            return bool(query.strip())
+            return False
         return bool(_needs_memory_context(query, "hermes", "context-engine", ""))
 
     def _handles_message_for(
@@ -312,15 +321,19 @@ class IchorContextEngine(ContextEngine):
         end = int(end_text)
         rows = self._raw_turns_by_session.get(session_id, [])
         selected = [row for row in rows if start <= int(row.get("seq", -1)) <= end]
-        content = "\n".join(
+        full_content = "\n".join(
             f"[{row['seq']}] {row['message'].get('role')}: {row['message'].get('content', '')}"
             for row in selected
         )
+        truncated = len(full_content) > self.max_expand_chars
+        content = full_content[: self.max_expand_chars]
         return {
             "ok": bool(selected),
             "source_id": source_id,
             "count": len(selected),
             "content": content,
+            "truncated": truncated,
+            "omitted_chars": max(0, len(full_content) - len(content)),
         }
 
 

--- a/hermes-agent/plugins/context_engine/ichor/__init__.py
+++ b/hermes-agent/plugins/context_engine/ichor/__init__.py
@@ -5,10 +5,10 @@ This engine implements the first bounded per-turn selector shape from
 ``context.engine: ichor`` is configured; the default remains the built-in
 compressor.
 
-v0 intentionally keeps raw-turn ingestion in process memory. That gives the
-engine exact recall/expand handles and tokens-per-turn measurement without
-mutating live profile state, re-enabling hermes-lcm, rotating sessions, or
-calling an LLM/API in the hot path.
+By default the prototype keeps raw-turn ingestion in process memory. When an
+explicit RawTurnStore is provided by tests or future default-off wiring, it also
+persists exact turns to Ichor SQLite. Either way it avoids live profile mutation,
+re-enabling hermes-lcm, rotating sessions, or calling an LLM/API in the hot path.
 """
 from __future__ import annotations
 
@@ -24,6 +24,11 @@ try:
 except Exception:  # pragma: no cover - import failure is handled at runtime
     build_context_pack = None
     _needs_memory_context = None
+
+try:
+    from lib.ichor.raw_turns import RawTurnStore
+except Exception:  # pragma: no cover - optional persistence stays default-off
+    RawTurnStore = None
 
 
 _DEFAULT_METRICS = {
@@ -73,6 +78,7 @@ class IchorContextEngine(ContextEngine):
         max_pack_items: int = 8,
         max_pack_ms: int = 120,
         max_expand_chars: int = 12_000,
+        raw_turn_store: Any = None,
         context_length: int = 128_000,
         threshold_percent: float = 0.50,
     ) -> None:
@@ -90,7 +96,10 @@ class IchorContextEngine(ContextEngine):
         self.last_total_tokens = 0
         self.session_id = ""
         self.platform = ""
+        self.raw_turn_store = raw_turn_store
         self._raw_turns_by_session: dict[str, list[dict[str, Any]]] = {}
+        self._raw_turn_store_result: dict[str, Any] | None = None
+        self._raw_turn_store_error = ""
         self._last_selected_source_links: list[dict[str, str]] = []
         self._last_pack_metrics: dict[str, int] = dict(_DEFAULT_METRICS)
         self._last_assembled_tokens = 0
@@ -210,6 +219,22 @@ class IchorContextEngine(ContextEngine):
 
     def get_status(self) -> dict[str, Any]:
         base = super().get_status()
+        raw_store_status: dict[str, Any]
+        if self.raw_turn_store is None:
+            raw_store_status = {"configured": False}
+        else:
+            frontier = None
+            if self.session_id and hasattr(self.raw_turn_store, "get_frontier"):
+                try:
+                    frontier = self.raw_turn_store.get_frontier(self.session_id)
+                except Exception as exc:
+                    self._raw_turn_store_error = exc.__class__.__name__
+            raw_store_status = {
+                "configured": True,
+                "last_result": self._raw_turn_store_result,
+                "last_error": self._raw_turn_store_error,
+                "frontier": frontier,
+            }
         base.update({
             "mode": "default_off_plugin",
             "session_id": self.session_id,
@@ -220,6 +245,7 @@ class IchorContextEngine(ContextEngine):
             "last_injected": self._last_injected,
             "last_pack_metrics": dict(self._last_pack_metrics),
             "last_source_links": list(self._last_selected_source_links),
+            "raw_turn_store": raw_store_status,
         })
         return base
 
@@ -228,6 +254,20 @@ class IchorContextEngine(ContextEngine):
             {"seq": idx, "message": _safe_message_copy(message)}
             for idx, message in enumerate(messages)
         ]
+        if self.raw_turn_store is None:
+            return
+        try:
+            active_tail_start_seq = max(0, len(messages) - self.fresh_tail_turns)
+            self._raw_turn_store_result = self.raw_turn_store.ingest_messages(
+                session_id,
+                [_safe_message_copy(message) for message in messages],
+                source="context_engine",
+                active_tail_start_seq=active_tail_start_seq,
+            )
+            self._raw_turn_store_error = ""
+        except Exception as exc:
+            self._raw_turn_store_result = None
+            self._raw_turn_store_error = exc.__class__.__name__
 
     def _context_message_for(self, query: str) -> dict[str, str] | None:
         self._last_injected = False
@@ -321,10 +361,25 @@ class IchorContextEngine(ContextEngine):
         end = int(end_text)
         rows = self._raw_turns_by_session.get(session_id, [])
         selected = [row for row in rows if start <= int(row.get("seq", -1)) <= end]
-        full_content = "\n".join(
-            f"[{row['seq']}] {row['message'].get('role')}: {row['message'].get('content', '')}"
-            for row in selected
-        )
+        source = "in_memory"
+        if selected:
+            full_content = "\n".join(
+                f"[{row['seq']}] {row['message'].get('role')}: {row['message'].get('content', '')}"
+                for row in selected
+            )
+        elif self.raw_turn_store is not None and hasattr(self.raw_turn_store, "fetch_range"):
+            try:
+                persisted = self.raw_turn_store.fetch_range(session_id, start, end)
+                selected = [{"seq": row.seq, "message": {"role": row.role, "content": row.content}} for row in persisted]
+                full_content = "\n".join(
+                    f"[{row.seq}] {row.role}: {row.content}"
+                    for row in persisted
+                )
+                source = "persistent_store"
+            except Exception as exc:
+                return {"ok": False, "error": exc.__class__.__name__, "source_id": source_id}
+        else:
+            full_content = ""
         truncated = len(full_content) > self.max_expand_chars
         content = full_content[: self.max_expand_chars]
         return {
@@ -332,6 +387,7 @@ class IchorContextEngine(ContextEngine):
             "source_id": source_id,
             "count": len(selected),
             "content": content,
+            "source": source,
             "truncated": truncated,
             "omitted_chars": max(0, len(full_content) - len(content)),
         }

--- a/hermes-agent/plugins/context_engine/ichor/__init__.py
+++ b/hermes-agent/plugins/context_engine/ichor/__init__.py
@@ -1,0 +1,328 @@
+"""Default-off Ichor precision context engine prototype.
+
+This engine implements the first bounded per-turn selector shape from
+``docs/specs/ichor-precision-context-engine.md``. It is only selected when
+``context.engine: ichor`` is configured; the default remains the built-in
+compressor.
+
+v0 intentionally keeps raw-turn ingestion in process memory. That gives the
+engine exact recall/expand handles and tokens-per-turn measurement without
+mutating live profile state, re-enabling hermes-lcm, rotating sessions, or
+calling an LLM/API in the hot path.
+"""
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from typing import Any
+
+from agent.context_engine import ContextEngine
+
+try:
+    from lib.ichor.context_pack import build_context_pack, _needs_memory_context
+except Exception:  # pragma: no cover - import failure is handled at runtime
+    build_context_pack = None
+    _needs_memory_context = None
+
+
+_DEFAULT_METRICS = {
+    "llm_calls": 0,
+    "api_calls": 0,
+    "db_reads": 0,
+    "db_writes": 0,
+    "tokens_estimated": 0,
+}
+
+
+def _estimate_text_tokens(text: str) -> int:
+    return max(1, (len(text) + 3) // 4) if text else 0
+
+
+def _estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
+    return sum(_estimate_text_tokens(str(message.get("content", ""))) for message in messages)
+
+
+def _latest_user_message(messages: list[dict[str, Any]]) -> str:
+    for message in reversed(messages):
+        if message.get("role") == "user":
+            return str(message.get("content", ""))
+    return ""
+
+
+def _safe_message_copy(message: dict[str, Any]) -> dict[str, Any]:
+    return deepcopy(message)
+
+
+class IchorContextEngine(ContextEngine):
+    """Bounded per-turn context selector backed by Ichor context packs.
+
+    This v0 is a default-off prototype. It validates the ContextEngine seam and
+    per-turn economy benchmark before any fleet/profile promotion.
+    """
+
+    @property
+    def name(self) -> str:
+        return "ichor"
+
+    def __init__(
+        self,
+        *,
+        fresh_tail_turns: int = 8,
+        max_pack_tokens: int = 900,
+        max_pack_items: int = 8,
+        max_pack_ms: int = 120,
+        context_length: int = 128_000,
+        threshold_percent: float = 0.50,
+    ) -> None:
+        self.fresh_tail_turns = max(1, int(fresh_tail_turns))
+        self.max_pack_tokens = max(1, int(max_pack_tokens))
+        self.max_pack_items = max(1, int(max_pack_items))
+        self.max_pack_ms = max(1, int(max_pack_ms))
+        self.threshold_percent = threshold_percent
+        self.context_length = int(context_length)
+        self.threshold_tokens = int(self.context_length * self.threshold_percent)
+        self.compression_count = 0
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
+        self.session_id = ""
+        self.platform = ""
+        self._raw_turns_by_session: dict[str, list[dict[str, Any]]] = {}
+        self._last_selected_source_links: list[dict[str, str]] = []
+        self._last_pack_metrics: dict[str, int] = dict(_DEFAULT_METRICS)
+        self._last_assembled_tokens = 0
+        self._last_original_tokens = 0
+        self._last_injected = False
+
+    def is_available(self) -> bool:
+        return True
+
+    def update_model(
+        self,
+        model: str,
+        context_length: int,
+        base_url: str = "",
+        api_key: str = "",
+        provider: str = "",
+        api_mode: str = "",
+    ) -> None:
+        del model, base_url, api_key, provider, api_mode
+        self.context_length = int(context_length or self.context_length)
+        self.threshold_tokens = int(self.context_length * self.threshold_percent)
+
+    def update_from_response(self, usage: dict[str, Any]) -> None:
+        self.last_prompt_tokens = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+        self.last_completion_tokens = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+        self.last_total_tokens = int(usage.get("total_tokens") or (self.last_prompt_tokens + self.last_completion_tokens))
+
+    def should_compress(self, prompt_tokens: int = None) -> bool:
+        tokens = self.last_prompt_tokens if prompt_tokens is None else int(prompt_tokens or 0)
+        return tokens >= self.threshold_tokens
+
+    def should_compress_preflight(self, messages: list[dict[str, Any]]) -> bool:
+        return self.has_content_to_compress(messages)
+
+    def has_content_to_compress(self, messages: list[dict[str, Any]]) -> bool:
+        non_system = [m for m in messages if m.get("role") != "system"]
+        return len(non_system) > self.fresh_tail_turns
+
+    def on_session_start(self, session_id: str, **kwargs: Any) -> None:
+        self.session_id = session_id or self.session_id or "ichor-session"
+        self.platform = str(kwargs.get("platform") or self.platform or "")
+        self._raw_turns_by_session.setdefault(self.session_id, [])
+
+    def on_session_reset(self) -> None:
+        super().on_session_reset()
+        self._last_selected_source_links = []
+        self._last_pack_metrics = dict(_DEFAULT_METRICS)
+        self._last_assembled_tokens = 0
+        self._last_original_tokens = 0
+        self._last_injected = False
+
+    def compress(
+        self,
+        messages: list[dict[str, Any]],
+        current_tokens: int = None,
+        focus_topic: str = None,
+        force: bool = False,
+    ) -> list[dict[str, Any]]:
+        del force
+        session_id = self.session_id or "ichor-session"
+        self._ingest_raw_turns(session_id, messages)
+        query = focus_topic or _latest_user_message(messages)
+        systems = [_safe_message_copy(m) for m in messages if m.get("role") == "system"]
+        non_system = [_safe_message_copy(m) for m in messages if m.get("role") != "system"]
+        fresh_tail = non_system[-self.fresh_tail_turns:]
+
+        context_message = self._context_message_for(query)
+        handles_message = self._handles_message_for(session_id, messages, fresh_tail)
+
+        assembled: list[dict[str, Any]] = []
+        assembled.extend(systems)
+        if context_message is not None:
+            assembled.append(context_message)
+        if handles_message is not None:
+            assembled.append(handles_message)
+        assembled.extend(fresh_tail)
+
+        self.compression_count += 1
+        self._last_original_tokens = int(current_tokens or _estimate_messages_tokens(messages))
+        self._last_assembled_tokens = _estimate_messages_tokens(assembled)
+        self.last_prompt_tokens = self._last_assembled_tokens
+        return assembled
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "ichor_status",
+                "description": "Inspect the active Ichor context engine frontier and last selected context metrics.",
+                "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+            },
+            {
+                "name": "ichor_expand",
+                "description": "Expand exact raw-turn context by source_id handle such as raw_turns:<session>:seq:1-3.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "source_id": {"type": "string", "description": "Raw turn range or source handle to expand."}
+                    },
+                    "required": ["source_id"],
+                    "additionalProperties": False,
+                },
+            },
+        ]
+
+    def handle_tool_call(self, name: str, args: dict[str, Any], **kwargs: Any) -> str:
+        del kwargs
+        if name == "ichor_status":
+            return json.dumps({"ok": True, "status": self.get_status()})
+        if name == "ichor_expand":
+            return json.dumps(self._expand_source(str(args.get("source_id", ""))))
+        return json.dumps({"ok": False, "error": f"Unknown Ichor context engine tool: {name}"})
+
+    def get_status(self) -> dict[str, Any]:
+        base = super().get_status()
+        base.update({
+            "mode": "default_off_plugin",
+            "session_id": self.session_id,
+            "fresh_tail_turns": self.fresh_tail_turns,
+            "max_pack_tokens": self.max_pack_tokens,
+            "last_original_tokens": self._last_original_tokens,
+            "last_assembled_tokens": self._last_assembled_tokens,
+            "last_injected": self._last_injected,
+            "last_pack_metrics": dict(self._last_pack_metrics),
+            "last_source_links": list(self._last_selected_source_links),
+        })
+        return base
+
+    def _ingest_raw_turns(self, session_id: str, messages: list[dict[str, Any]]) -> None:
+        self._raw_turns_by_session[session_id] = [
+            {"seq": idx, "message": _safe_message_copy(message)}
+            for idx, message in enumerate(messages)
+        ]
+
+    def _context_message_for(self, query: str) -> dict[str, str] | None:
+        self._last_injected = False
+        self._last_selected_source_links = []
+        self._last_pack_metrics = dict(_DEFAULT_METRICS)
+        if not self._needs_context(query):
+            return None
+        try:
+            pack = self._build_context_pack(query=query)
+        except Exception as exc:
+            self._last_pack_metrics = dict(_DEFAULT_METRICS)
+            return {
+                "role": "system",
+                "content": f"<ichor-context status=\"unavailable\" error=\"{exc.__class__.__name__}\" />",
+            }
+        metrics = dict(_DEFAULT_METRICS)
+        metrics.update({key: int(value or 0) for key, value in (pack.get("metrics") or {}).items() if key in metrics})
+        self._last_pack_metrics = metrics
+        self._last_selected_source_links = list(pack.get("source_links") or [])
+        context = str(pack.get("injectable_context") or "").strip()
+        if not context:
+            return None
+        self._last_injected = True
+        return {"role": "system", "content": context}
+
+    def _build_context_pack(self, *, query: str) -> dict[str, Any]:
+        if build_context_pack is None:
+            raise RuntimeError("Ichor context pack builder unavailable")
+        return build_context_pack(
+            query,
+            god_name="hermes",
+            phase="context-engine",
+            task_type="context",
+            max_items=self.max_pack_items,
+            max_tokens=self.max_pack_tokens,
+            max_ms=self.max_pack_ms,
+            include_graph=False,
+            dry_run=True,
+        )
+
+    def _needs_context(self, query: str) -> bool:
+        lowered = (query or "").lower()
+        explicit_markers = (
+            "ichor",
+            "context",
+            "compress",
+            "benchmark",
+            "frontier",
+            "recall",
+            "expand",
+        )
+        if any(marker in lowered for marker in explicit_markers):
+            return True
+        if _needs_memory_context is None:
+            return bool(query.strip())
+        return bool(_needs_memory_context(query, "hermes", "context-engine", ""))
+
+    def _handles_message_for(
+        self,
+        session_id: str,
+        messages: list[dict[str, Any]],
+        fresh_tail: list[dict[str, Any]],
+    ) -> dict[str, str] | None:
+        omitted_count = max(0, len([m for m in messages if m.get("role") != "system"]) - len(fresh_tail))
+        if omitted_count <= 0:
+            return None
+        last_omitted_seq = max(0, len(messages) - len(fresh_tail) - 1)
+        source_id = f"raw_turns:{session_id}:seq:1-{last_omitted_seq}"
+        source_lines = [
+            "Available Ichor expansions:",
+            f"- {source_id} — exact raw turns omitted from the live prompt frontier",
+        ]
+        for link in self._last_selected_source_links[:4]:
+            source_lines.append(
+                "- source:{path}#{sid} — {title}".format(
+                    path=link.get("source_path", ""),
+                    sid=link.get("source_id", ""),
+                    title=link.get("title", "Ichor source"),
+                )
+            )
+        return {"role": "system", "content": "\n".join(source_lines)}
+
+    def _expand_source(self, source_id: str) -> dict[str, Any]:
+        match = re.fullmatch(r"raw_turns:([^:]+):seq:(\d+)-(\d+)", source_id)
+        if not match:
+            return {"ok": False, "error": "unsupported_source_id", "source_id": source_id}
+        session_id, start_text, end_text = match.groups()
+        start = int(start_text)
+        end = int(end_text)
+        rows = self._raw_turns_by_session.get(session_id, [])
+        selected = [row for row in rows if start <= int(row.get("seq", -1)) <= end]
+        content = "\n".join(
+            f"[{row['seq']}] {row['message'].get('role')}: {row['message'].get('content', '')}"
+            for row in selected
+        )
+        return {
+            "ok": bool(selected),
+            "source_id": source_id,
+            "count": len(selected),
+            "content": content,
+        }
+
+
+def register(ctx: Any) -> None:
+    ctx.register_context_engine(IchorContextEngine())

--- a/hermes-agent/plugins/context_engine/ichor/plugin.yaml
+++ b/hermes-agent/plugins/context_engine/ichor/plugin.yaml
@@ -1,0 +1,10 @@
+name: ichor
+description: Default-off Ichor precision context engine prototype for bounded per-turn context selection.
+version: 0.1.0
+category: context_engine
+status: experimental
+notes:
+  - Selected only when config.yaml sets context.engine: ichor.
+  - Does not re-enable hermes-lcm.
+  - Designed to assemble bounded source-backed context per turn.
+  - Keeps compaction as fallback, not normal flow.

--- a/lib/ichor/raw_turns.py
+++ b/lib/ichor/raw_turns.py
@@ -1,0 +1,231 @@
+"""Lossless raw-turn storage for the Ichor context engine.
+
+This module is intentionally small and deterministic. It owns only exact raw
+message persistence and a compact session frontier; derived extraction belongs
+to later Ichor enrichment lanes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_TABLES = ["ichor_raw_turns", "ichor_session_frontier"]
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS ichor_raw_turns (
+    session_id TEXT NOT NULL,
+    seq INTEGER NOT NULL,
+    role TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    content TEXT NOT NULL,
+    message_json TEXT NOT NULL,
+    tool_name TEXT,
+    tool_call_id TEXT,
+    source TEXT NOT NULL DEFAULT 'context_engine',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (session_id, seq)
+);
+CREATE INDEX IF NOT EXISTS idx_ichor_raw_turns_hash ON ichor_raw_turns(content_hash);
+CREATE INDEX IF NOT EXISTS idx_ichor_raw_turns_created ON ichor_raw_turns(created_at DESC);
+
+CREATE TABLE IF NOT EXISTS ichor_session_frontier (
+    session_id TEXT PRIMARY KEY,
+    last_ingested_seq INTEGER NOT NULL,
+    active_tail_start_seq INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+"""
+
+
+@dataclass(frozen=True)
+class RawTurn:
+    """One exact stored message from a Hermes session."""
+
+    session_id: str
+    seq: int
+    role: str
+    content: str
+    content_hash: str
+    message_json: str
+    tool_name: str | None = None
+    tool_call_id: str | None = None
+    source: str = "context_engine"
+    created_at: str | None = None
+
+
+class RawTurnStore:
+    """SQLite repository for exact raw turns and session frontiers."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.db_path = Path(db_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def migrate(self) -> dict[str, object]:
+        """Create raw-turn tables and indexes. Idempotent."""
+        with self._connect() as conn:
+            conn.executescript(SCHEMA_SQL)
+            conn.commit()
+            ready = [
+                table
+                for table in SCHEMA_TABLES
+                if conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+                    (table,),
+                ).fetchone()
+            ]
+        return {"tables_ready": ready}
+
+    def ingest_messages(
+        self,
+        session_id: str,
+        messages: list[dict[str, Any]],
+        *,
+        source: str = "context_engine",
+        active_tail_start_seq: int = 0,
+    ) -> dict[str, int]:
+        """Idempotently persist exact messages by ``(session_id, seq)``.
+
+        Existing rows are updated only when the content hash changes. Replaying
+        the same transcript therefore stays a no-op after the first insert.
+        """
+        self.migrate()
+        inserted = 0
+        updated = 0
+        last_seq = len(messages) - 1
+        with self._connect() as conn:
+            for seq, message in enumerate(messages):
+                normalized = self._normalize_message(message)
+                existing = conn.execute(
+                    "SELECT content_hash FROM ichor_raw_turns WHERE session_id=? AND seq=?",
+                    (session_id, seq),
+                ).fetchone()
+                params = (
+                    session_id,
+                    seq,
+                    normalized["role"],
+                    normalized["content_hash"],
+                    normalized["content"],
+                    normalized["message_json"],
+                    normalized["tool_name"],
+                    normalized["tool_call_id"],
+                    source,
+                )
+                if existing is None:
+                    conn.execute(
+                        """
+                        INSERT INTO ichor_raw_turns (
+                            session_id, seq, role, content_hash, content,
+                            message_json, tool_name, tool_call_id, source
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        params,
+                    )
+                    inserted += 1
+                elif existing["content_hash"] != normalized["content_hash"]:
+                    conn.execute(
+                        """
+                        UPDATE ichor_raw_turns
+                        SET role=?, content_hash=?, content=?, message_json=?,
+                            tool_name=?, tool_call_id=?, source=?, updated_at=datetime('now')
+                        WHERE session_id=? AND seq=?
+                        """,
+                        (
+                            normalized["role"],
+                            normalized["content_hash"],
+                            normalized["content"],
+                            normalized["message_json"],
+                            normalized["tool_name"],
+                            normalized["tool_call_id"],
+                            source,
+                            session_id,
+                            seq,
+                        ),
+                    )
+                    updated += 1
+            conn.execute(
+                """
+                INSERT INTO ichor_session_frontier (
+                    session_id, last_ingested_seq, active_tail_start_seq
+                ) VALUES (?, ?, ?)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    last_ingested_seq=excluded.last_ingested_seq,
+                    active_tail_start_seq=excluded.active_tail_start_seq,
+                    updated_at=datetime('now')
+                """,
+                (session_id, last_seq, max(0, int(active_tail_start_seq))),
+            )
+            conn.commit()
+        return {"seen": len(messages), "inserted": inserted, "updated": updated, "last_seq": last_seq}
+
+    def fetch_range(self, session_id: str, start_seq: int, end_seq: int) -> list[RawTurn]:
+        """Fetch exact raw turns for ``session_id`` in sequence order."""
+        self.migrate()
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT session_id, seq, role, content, content_hash, message_json,
+                       tool_name, tool_call_id, source, created_at
+                FROM ichor_raw_turns
+                WHERE session_id=? AND seq BETWEEN ? AND ?
+                ORDER BY seq ASC
+                """,
+                (session_id, int(start_seq), int(end_seq)),
+            ).fetchall()
+        return [RawTurn(**dict(row)) for row in rows]
+
+    def get_frontier(self, session_id: str) -> dict[str, Any] | None:
+        """Return compact frontier state without volatile timestamp fields."""
+        self.migrate()
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT session_id, last_ingested_seq, active_tail_start_seq
+                FROM ichor_session_frontier WHERE session_id=?
+                """,
+                (session_id,),
+            ).fetchone()
+        return dict(row) if row else None
+
+    @staticmethod
+    def _normalize_message(message: dict[str, Any]) -> dict[str, str | None]:
+        message_json = json.dumps(message, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        content = message.get("content", "")
+        if not isinstance(content, str):
+            content = json.dumps(content, ensure_ascii=False, sort_keys=True)
+        content_hash = hashlib.sha256(message_json.encode("utf-8")).hexdigest()
+        role = str(message.get("role") or "unknown")
+        tool_name = RawTurnStore._tool_name(message)
+        tool_call_id = message.get("tool_call_id")
+        return {
+            "role": role,
+            "content": content,
+            "content_hash": content_hash,
+            "message_json": message_json,
+            "tool_name": str(tool_name) if tool_name else None,
+            "tool_call_id": str(tool_call_id) if tool_call_id else None,
+        }
+
+    @staticmethod
+    def _tool_name(message: dict[str, Any]) -> str | None:
+        if message.get("name"):
+            return str(message["name"])
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, list) and tool_calls:
+            first = tool_calls[0]
+            if isinstance(first, dict):
+                function = first.get("function")
+                if isinstance(function, dict) and function.get("name"):
+                    return str(function["name"])
+        return None

--- a/scripts/benchmark-ichor-context-engine-turns.py
+++ b/scripts/benchmark-ichor-context-engine-turns.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Benchmark default-off IchorContextEngine on tokens sent per turn.
+
+This is the measurement gate for the course-correction marker: compare per-turn
+prompt economy, not just post-threshold compression size. It is offline,
+default-off, and does not mutate live Hermes profile/fleet configuration.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from types import MethodType
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+HERMES_AGENT = ROOT / "hermes-agent"
+for candidate in (str(HERMES_AGENT), str(ROOT)):
+    if candidate in sys.path:
+        sys.path.remove(candidate)
+for candidate in (str(ROOT), str(HERMES_AGENT)):
+    sys.path.insert(0, candidate)
+
+
+@dataclass(frozen=True)
+class TurnCase:
+    case_id: str
+    query: str
+    turns: int
+    expect_pack: bool
+    filler_topic: str
+
+
+CASES = (
+    TurnCase(
+        case_id="ichor-engine-build",
+        query="Build the default-off IchorContextEngine prototype and benchmark tokens per turn.",
+        turns=7,
+        expect_pack=True,
+        filler_topic="Ichor precision context engine benchmark source-backed recall frontier",
+    ),
+    TurnCase(
+        case_id="pr138-comparison",
+        query="Compare PR #138 with the Ichor context engine replacement path.",
+        turns=7,
+        expect_pack=True,
+        filler_topic="PR #138 compressor-weight benchmark context pack default compressor comparison",
+    ),
+    TurnCase(
+        case_id="casual-noop",
+        query="ok",
+        turns=7,
+        expect_pack=False,
+        filler_topic="casual acknowledgement unrelated filler weather chatter low signal",
+    ),
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _default_artifact_dir() -> Path:
+    return Path("/tmp") / f"ichor-context-engine-turn-benchmark-{_utc_stamp()}"
+
+
+def _ensure_private_artifact_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.chmod(0o700)
+
+
+def _estimate_text_tokens(text: str) -> int:
+    return max(1, (len(text) + 3) // 4) if text else 0
+
+
+def estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
+    return sum(_estimate_text_tokens(str(message.get("content", ""))) for message in messages)
+
+
+def _long_payload(case: TurnCase, turn: int, role: str) -> str:
+    core = (
+        f"{case.filler_topic} | turn={turn} | role={role} | "
+        "This is accumulated historical context that should remain exactly recallable "
+        "without being resent in full every turn. "
+    )
+    if case.expect_pack:
+        core += (
+            "Relevant durable constraints: Ichor is the lossless memory substrate; "
+            "IchorContextEngine is the bounded per-turn selector; compaction is fallback. "
+        )
+    else:
+        core += "No durable memory context should be selected for the current no-op acknowledgement. "
+    return core * 26
+
+
+def _assistant_payload(case: TurnCase, turn: int) -> str:
+    return (
+        f"Assistant response for {case.case_id} turn {turn}. "
+        "Keep exact raw-turn expansion possible while avoiding stale prompt cargo. "
+    ) * 18
+
+
+def _fake_summary(case: TurnCase, counter: dict[str, int], _self: Any, turns: list[dict[str, Any]], focus_topic: str | None = None) -> str:
+    counter["llm_calls"] += 1
+    return "\n".join([
+        "## Historical Task Snapshot",
+        f"Default-compressor fake summary for {case.case_id}.",
+        f"Focus topic: {focus_topic or case.query}.",
+        f"Compressed turns: {len(turns)}.",
+        "## Key Decisions",
+        "- Ichor should reduce tokens per turn by selecting only relevant source-backed context.",
+        "- Default compressor remains the measured baseline, not the destination.",
+    ])
+
+
+def _new_default_compressor(case: TurnCase) -> tuple[Any, dict[str, int]]:
+    from agent.context_compressor import ContextCompressor
+
+    compressor = ContextCompressor(
+        model="ichor-context-engine-turn-benchmark",
+        quiet_mode=True,
+        config_context_length=128_000,
+    )
+    counter = {"llm_calls": 0}
+
+    def bound_fake_summary(self: Any, turns: list[dict[str, Any]], focus_topic: str | None = None) -> str:
+        return _fake_summary(case, counter, self, turns, focus_topic)
+
+    compressor._generate_summary = MethodType(bound_fake_summary, compressor)  # type: ignore[attr-defined]
+    return compressor, counter
+
+
+def _new_ichor_engine() -> Any:
+    import importlib
+
+    for loaded in list(sys.modules):
+        if loaded == "plugins" or loaded.startswith("plugins.context_engine"):
+            del sys.modules[loaded]
+    if str(HERMES_AGENT) in sys.path:
+        sys.path.remove(str(HERMES_AGENT))
+    sys.path.insert(0, str(HERMES_AGENT))
+    module = importlib.import_module("plugins.context_engine.ichor")
+    engine = module.IchorContextEngine(fresh_tail_turns=6, max_pack_tokens=700, max_pack_ms=120)
+    engine.on_session_start("turn-benchmark")
+    return engine
+
+
+def _simulate_default(case: TurnCase) -> dict[str, Any]:
+    compressor, counter = _new_default_compressor(case)
+    active_messages: list[dict[str, str]] = [{"role": "system", "content": "Default compressor per-turn benchmark."}]
+    per_turn: list[dict[str, Any]] = []
+    for turn in range(1, case.turns + 1):
+        active_messages.append({"role": "user", "content": _long_payload(case, turn, "user") + "\nCurrent request: " + case.query})
+        before = estimate_messages_tokens(active_messages)
+        compressed_this_turn = False
+        if compressor.should_compress(before) and compressor.has_content_to_compress(active_messages):
+            active_messages = compressor.compress(copy.deepcopy(active_messages), current_tokens=before, focus_topic=case.query, force=True)
+            compressed_this_turn = True
+        sent = estimate_messages_tokens(active_messages)
+        per_turn.append({"turn": turn, "tokens_sent": sent, "compressed": compressed_this_turn})
+        active_messages.append({"role": "assistant", "content": _assistant_payload(case, turn)})
+    return {
+        "engine": "default_compressor",
+        "total_tokens": sum(row["tokens_sent"] for row in per_turn),
+        "avg_tokens_per_turn": round(sum(row["tokens_sent"] for row in per_turn) / len(per_turn), 2),
+        "compressions": sum(1 for row in per_turn if row["compressed"]),
+        "llm_calls": counter["llm_calls"],
+        "api_calls": 0,
+        "per_turn": per_turn,
+    }
+
+
+def _simulate_ichor(case: TurnCase) -> dict[str, Any]:
+    engine = _new_ichor_engine()
+    raw_messages: list[dict[str, str]] = [{"role": "system", "content": "Ichor context engine per-turn benchmark."}]
+    per_turn: list[dict[str, Any]] = []
+    injected_any = False
+    noop_clean = True
+    handles_all = True
+    handles_any = False
+    llm_calls = 0
+    api_calls = 0
+    for turn in range(1, case.turns + 1):
+        raw_messages.append({"role": "user", "content": _long_payload(case, turn, "user") + "\nCurrent request: " + case.query})
+        assembled = engine.compress(copy.deepcopy(raw_messages), current_tokens=estimate_messages_tokens(raw_messages), focus_topic=case.query)
+        sent = estimate_messages_tokens(assembled)
+        joined = "\n".join(str(message.get("content", "")) for message in assembled)
+        status = engine.get_status()
+        metrics = status["last_pack_metrics"]
+        llm_calls += int(metrics.get("llm_calls", 0) or 0)
+        api_calls += int(metrics.get("api_calls", 0) or 0)
+        injected = bool(status.get("last_injected"))
+        injected_any = injected_any or injected
+        if not case.expect_pack:
+            noop_clean = noop_clean and not injected and int(metrics.get("db_reads", 0) or 0) == 0
+        frontier_omitted = len([message for message in raw_messages if message.get("role") != "system"]) > engine.fresh_tail_turns
+        has_handle = "Available Ichor expansions" in joined
+        if frontier_omitted:
+            handles_all = handles_all and has_handle
+            handles_any = handles_any or has_handle
+        per_turn.append({
+            "turn": turn,
+            "tokens_sent": sent,
+            "injected": injected,
+            "db_reads": int(metrics.get("db_reads", 0) or 0),
+            "frontier_omitted": frontier_omitted,
+            "has_expand_handle": has_handle,
+        })
+        raw_messages.append({"role": "assistant", "content": _assistant_payload(case, turn)})
+    return {
+        "engine": "ichor_context_engine",
+        "total_tokens": sum(row["tokens_sent"] for row in per_turn),
+        "avg_tokens_per_turn": round(sum(row["tokens_sent"] for row in per_turn) / len(per_turn), 2),
+        "injected_any": injected_any,
+        "noop_clean": noop_clean,
+        "all_turns_have_expand_handles": handles_all and handles_any,
+        "llm_calls": llm_calls,
+        "api_calls": api_calls,
+        "per_turn": per_turn,
+    }
+
+
+def run_case(case: TurnCase, artifact_dir: Path) -> dict[str, Any]:
+    started = time.perf_counter()
+    default = _simulate_default(case)
+    ichor = _simulate_ichor(case)
+    row_ready = ichor["total_tokens"] < default["total_tokens"]
+    if case.expect_pack:
+        row_ready = row_ready and bool(ichor["injected_any"])
+    else:
+        row_ready = row_ready and bool(ichor["noop_clean"])
+    row = {
+        "case_id": case.case_id,
+        "query": case.query,
+        "turns": case.turns,
+        "expect_pack": case.expect_pack,
+        "default_compressor": default,
+        "ichor_context_engine": ichor,
+        "tokens_saved": default["total_tokens"] - ichor["total_tokens"],
+        "tokens_saved_ratio": round((default["total_tokens"] - ichor["total_tokens"]) / max(default["total_tokens"], 1), 4),
+        "row_ready": row_ready,
+        "wall_ms": int((time.perf_counter() - started) * 1000),
+        "would_mutate_runtime": False,
+        "would_change_config": False,
+        "would_enable_lcm": False,
+        "would_flip_fleet_default": False,
+    }
+    (artifact_dir / f"{case.case_id}.json").write_text(json.dumps(row, indent=2, sort_keys=True), encoding="utf-8")
+    return row
+
+
+def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    default_total = sum(row["default_compressor"]["total_tokens"] for row in rows)
+    ichor_total = sum(row["ichor_context_engine"]["total_tokens"] for row in rows)
+    turns = sum(int(row["turns"]) for row in rows)
+    blockers: list[str] = []
+    if ichor_total >= default_total:
+        blockers.append("ichor_not_lower_total_tokens")
+    if not all(row["row_ready"] for row in rows):
+        blockers.append("row_not_ready")
+    if not all(row["ichor_context_engine"]["llm_calls"] == 0 and row["ichor_context_engine"]["api_calls"] == 0 for row in rows):
+        blockers.append("ichor_hot_path_llm_or_api")
+    noop_rows = [row for row in rows if not row["expect_pack"]]
+    if not all(row["ichor_context_engine"]["noop_clean"] for row in noop_rows):
+        blockers.append("noop_not_clean")
+    if not all(row["ichor_context_engine"]["all_turns_have_expand_handles"] for row in rows):
+        blockers.append("missing_expand_handles")
+    return {
+        "rows_run": len(rows),
+        "turns_run": turns,
+        "default_total_tokens": default_total,
+        "ichor_total_tokens": ichor_total,
+        "tokens_saved": default_total - ichor_total,
+        "tokens_saved_ratio": round((default_total - ichor_total) / max(default_total, 1), 4),
+        "default_avg_tokens_per_turn": round(default_total / max(turns, 1), 2),
+        "ichor_avg_tokens_per_turn": round(ichor_total / max(turns, 1), 2),
+        "all_ichor_no_llm_api": all(row["ichor_context_engine"]["llm_calls"] == 0 and row["ichor_context_engine"]["api_calls"] == 0 for row in rows),
+        "all_noop_rows_clean": all(row["ichor_context_engine"]["noop_clean"] for row in noop_rows),
+        "all_rows_have_expand_handles": all(row["ichor_context_engine"]["all_turns_have_expand_handles"] for row in rows),
+        "all_no_runtime_mutation": all(not row["would_mutate_runtime"] and not row["would_change_config"] and not row["would_enable_lcm"] and not row["would_flip_fleet_default"] for row in rows),
+        "blockers": blockers,
+        "benchmark_ready": not blockers,
+    }
+
+
+def _write_report(path: Path, summary: dict[str, Any], rows: list[dict[str, Any]]) -> None:
+    lines = [
+        "# IchorContextEngine Tokens-Per-Turn Benchmark",
+        "",
+        f"- Benchmark ready: `{summary['benchmark_ready']}`",
+        f"- Default total tokens: `{summary['default_total_tokens']}`",
+        f"- Ichor total tokens: `{summary['ichor_total_tokens']}`",
+        f"- Tokens saved ratio: `{summary['tokens_saved_ratio']}`",
+        f"- Ichor avg tokens/turn: `{summary['ichor_avg_tokens_per_turn']}`",
+        "",
+        "| Case | Default total | Ichor total | Saved ratio | Ready |",
+        "| --- | ---: | ---: | ---: | --- |",
+    ]
+    for row in rows:
+        lines.append(
+            f"| {row['case_id']} | {row['default_compressor']['total_tokens']} | "
+            f"{row['ichor_context_engine']['total_tokens']} | {row['tokens_saved_ratio']} | {row['row_ready']} |"
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_benchmark(artifact_dir: Path | None = None) -> dict[str, Any]:
+    artifact_dir = artifact_dir or _default_artifact_dir()
+    _ensure_private_artifact_dir(artifact_dir)
+    rows = [run_case(case, artifact_dir) for case in CASES]
+    summary = _summarize(rows)
+    summary_path = artifact_dir / "summary.json"
+    report_path = artifact_dir / "BENCHMARK.md"
+    payload = {
+        "mode": "ichor_context_engine_turn_benchmark",
+        "artifact_dir": str(artifact_dir),
+        "summary": summary,
+        "rows": rows,
+        "summary_path": str(summary_path),
+        "report_path": str(report_path),
+    }
+    summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    _write_report(report_path, summary, rows)
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-dir", type=Path, default=None)
+    parser.add_argument("--format", choices=("json", "text"), default="text")
+    args = parser.parse_args(argv)
+    payload = run_benchmark(args.artifact_dir)
+    if args.format == "json":
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        summary = payload["summary"]
+        print(f"benchmark_ready={summary['benchmark_ready']} artifact_dir={payload['artifact_dir']}")
+    return 0 if payload["summary"]["benchmark_ready"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark-ichor-context-engine-turns.py
+++ b/scripts/benchmark-ichor-context-engine-turns.py
@@ -166,7 +166,9 @@ def _simulate_default(case: TurnCase) -> dict[str, Any]:
         per_turn.append({"turn": turn, "tokens_sent": sent, "compressed": compressed_this_turn})
         active_messages.append({"role": "assistant", "content": _assistant_payload(case, turn)})
     return {
-        "engine": "default_compressor",
+        "engine": "full_transcript_baseline_until_threshold",
+        "label": "full transcript resend baseline until compressor threshold",
+        "token_estimate_method": "len_div_4_heuristic",
         "total_tokens": sum(row["tokens_sent"] for row in per_turn),
         "avg_tokens_per_turn": round(sum(row["tokens_sent"] for row in per_turn) / len(per_turn), 2),
         "compressions": sum(1 for row in per_turn if row["compressed"]),
@@ -215,6 +217,7 @@ def _simulate_ichor(case: TurnCase) -> dict[str, Any]:
         raw_messages.append({"role": "assistant", "content": _assistant_payload(case, turn)})
     return {
         "engine": "ichor_context_engine",
+        "token_estimate_method": "len_div_4_heuristic",
         "total_tokens": sum(row["tokens_sent"] for row in per_turn),
         "avg_tokens_per_turn": round(sum(row["tokens_sent"] for row in per_turn) / len(per_turn), 2),
         "injected_any": injected_any,
@@ -274,6 +277,8 @@ def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "rows_run": len(rows),
         "turns_run": turns,
+        "baseline_label": "full transcript resend baseline until compressor threshold",
+        "token_estimate_method": "len_div_4_heuristic",
         "default_total_tokens": default_total,
         "ichor_total_tokens": ichor_total,
         "tokens_saved": default_total - ichor_total,
@@ -294,8 +299,10 @@ def _write_report(path: Path, summary: dict[str, Any], rows: list[dict[str, Any]
         "# IchorContextEngine Tokens-Per-Turn Benchmark",
         "",
         f"- Benchmark ready: `{summary['benchmark_ready']}`",
-        f"- Default total tokens: `{summary['default_total_tokens']}`",
-        f"- Ichor total tokens: `{summary['ichor_total_tokens']}`",
+        f"- Baseline: `{summary['baseline_label']}`",
+        f"- Token estimate method: `{summary['token_estimate_method']}`",
+        f"- Default/baseline estimated tokens: `{summary['default_total_tokens']}`",
+        f"- Ichor estimated tokens: `{summary['ichor_total_tokens']}`",
         f"- Tokens saved ratio: `{summary['tokens_saved_ratio']}`",
         f"- Ichor avg tokens/turn: `{summary['ichor_avg_tokens_per_turn']}`",
         "",

--- a/tests/test_ichor_context_engine.py
+++ b/tests/test_ichor_context_engine.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -179,3 +180,84 @@ def test_ichor_expand_caps_large_raw_turn_output() -> None:
     assert result["truncated"] is True
     assert result["omitted_chars"] > 0
     assert len(result["content"]) <= 1200
+
+
+def test_ichor_context_engine_persists_raw_turns_when_store_configured(tmp_path: Path) -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    from lib.ichor.raw_turns import RawTurnStore
+
+    store = RawTurnStore(tmp_path / "ichor.db")
+    engine = module.IchorContextEngine(fresh_tail_turns=2, raw_turn_store=store)
+    engine.on_session_start("session-persisted")
+    messages = _long_messages("Persist these turns exactly.")
+
+    engine.compress(messages, current_tokens=_estimate_tokens(messages))
+    status = engine.get_status()
+
+    assert status["raw_turn_store"]["configured"] is True
+    assert status["raw_turn_store"]["last_result"]["inserted"] == len(messages)
+    assert status["raw_turn_store"]["frontier"]["last_ingested_seq"] == len(messages) - 1
+    persisted = store.fetch_range("session-persisted", 1, 3)
+    assert persisted[0].content == "Original project goal: reduce context tokens."
+
+
+def test_ichor_context_engine_expands_from_persisted_store_after_memory_loss(tmp_path: Path) -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    from lib.ichor.raw_turns import RawTurnStore
+
+    store = RawTurnStore(tmp_path / "ichor.db")
+    engine = module.IchorContextEngine(fresh_tail_turns=2, raw_turn_store=store)
+    engine.on_session_start("session-store-expand")
+    messages = _long_messages("Persist then expand from store.")
+    engine.compress(messages, current_tokens=_estimate_tokens(messages))
+    engine._raw_turns_by_session.clear()
+
+    result = json.loads(engine.handle_tool_call(
+        "ichor_expand",
+        {"source_id": "raw_turns:session-store-expand:seq:1-3"},
+    ))
+
+    assert result["ok"] is True
+    assert result["source"] == "persistent_store"
+    assert "Original project goal" in result["content"]
+
+
+def test_ichor_context_engine_default_has_no_persistent_store() -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    engine = module.IchorContextEngine(fresh_tail_turns=2)
+    engine.on_session_start("session-default-no-store")
+    messages = _long_messages("No live DB mutation by default.")
+
+    engine.compress(messages, current_tokens=_estimate_tokens(messages))
+
+    assert engine.get_status()["raw_turn_store"] == {"configured": False}
+
+
+def test_ichor_context_engine_persistent_store_failure_is_prompt_quiet() -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+
+    class BrokenStore:
+        def ingest_messages(self, *_args, **_kwargs):
+            raise sqlite3.OperationalError("read only")
+
+        def get_frontier(self, _session_id):
+            raise sqlite3.OperationalError("read only")
+
+    engine = module.IchorContextEngine(fresh_tail_turns=2, raw_turn_store=BrokenStore())
+    engine.on_session_start("session-broken-store")
+    messages = _long_messages("ok")
+
+    assembled = engine.compress(messages, current_tokens=_estimate_tokens(messages))
+    joined = "\n".join(str(m.get("content", "")) for m in assembled)
+    status = engine.get_status()["raw_turn_store"]
+
+    assert "read only" not in joined
+    assert status["configured"] is True
+    assert status["last_result"] is None
+    assert status["last_error"] == "OperationalError"
+    result = json.loads(engine.handle_tool_call(
+        "ichor_expand",
+        {"source_id": "raw_turns:session-broken-store:seq:1-3"},
+    ))
+    assert result["ok"] is True
+    assert result["source"] == "in_memory"

--- a/tests/test_ichor_context_engine.py
+++ b/tests/test_ichor_context_engine.py
@@ -1,0 +1,150 @@
+"""RED tests for the default-off IchorContextEngine prototype.
+
+The target is not another sidecar context-pack gate. These tests define the
+minimum compressor-replacement surface from docs/specs/ichor-precision-context-engine.md:
+lossless turn ingestion, bounded per-turn assembly, exact recall handles, no-op
+cleanliness, and no LLM/API calls on the hot path.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HERMES_AGENT = ROOT / "hermes-agent"
+for candidate in (str(ROOT), str(HERMES_AGENT)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+# Pantheon also has a top-level `plugins` package. These tests target Hermes'
+# context-engine plugin loader, so evict any already-imported sibling package
+# and force the hermes-agent path to win.
+for loaded in list(sys.modules):
+    if loaded == "plugins" or loaded.startswith("plugins.context_engine"):
+        del sys.modules[loaded]
+if str(HERMES_AGENT) in sys.path:
+    sys.path.remove(str(HERMES_AGENT))
+sys.path.insert(0, str(HERMES_AGENT))
+
+
+def _long_messages(current_user: str) -> list[dict[str, str]]:
+    messages: list[dict[str, str]] = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "Original project goal: reduce context tokens."},
+        {"role": "assistant", "content": "Acknowledged."},
+    ]
+    for idx in range(24):
+        messages.append({
+            "role": "user",
+            "content": (
+                f"Stale middle user turn {idx}: old canary mechanics, gateway routing, "
+                "token rotation, and verbose logs that should not be pasted each turn. " * 8
+            ),
+        })
+        messages.append({
+            "role": "assistant",
+            "content": (
+                f"Stale middle assistant turn {idx}: implementation detail dump. "
+                "This text exists to make the transcript large and should become recallable, "
+                "not live prompt cargo. " * 8
+            ),
+        })
+    messages.extend([
+        {"role": "user", "content": "Fresh tail: PR #138 benchmark is ready."},
+        {"role": "assistant", "content": "Fresh tail: benchmark is source-backed and default-off."},
+        {"role": "user", "content": current_user},
+    ])
+    return messages
+
+
+def _estimate_tokens(messages: list[dict[str, str]]) -> int:
+    return sum(max(1, (len(str(m.get("content", ""))) + 3) // 4) for m in messages)
+
+
+def test_ichor_context_engine_plugin_loads_default_off() -> None:
+    from plugins.context_engine import discover_context_engines, load_context_engine
+
+    discovered = {name for name, _description, available in discover_context_engines() if available}
+    assert "ichor" in discovered
+
+    engine = load_context_engine("ichor")
+    assert engine is not None
+    assert engine.name == "ichor"
+    assert engine.get_status()["mode"] == "default_off_plugin"
+
+
+def test_ichor_context_engine_assembles_bounded_relevant_context(monkeypatch) -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    engine = module.IchorContextEngine(fresh_tail_turns=4, max_pack_tokens=220)
+    engine.on_session_start("session-1", platform="discord")
+
+    def fake_pack(**kwargs):
+        assert kwargs["query"] == "Build the default-off IchorContextEngine prototype."
+        return {
+            "injectable_context": "<ichor-context>source-backed engine target</ichor-context>",
+            "source_links": [
+                {"title": "precision context design", "source_path": "docs/specs/ichor-precision-context-engine.md", "source_id": "target"}
+            ],
+            "metrics": {"llm_calls": 0, "api_calls": 0, "db_reads": 1, "db_writes": 0, "tokens_estimated": 13},
+            "coverage": {"returned": 1, "warnings": []},
+        }
+
+    monkeypatch.setattr(engine, "_build_context_pack", fake_pack)
+    original = _long_messages("Build the default-off IchorContextEngine prototype.")
+
+    assembled = engine.compress(original, current_tokens=_estimate_tokens(original))
+    joined = "\n".join(str(m.get("content", "")) for m in assembled)
+
+    assert _estimate_tokens(assembled) < _estimate_tokens(original) * 0.35
+    assert assembled[0] == original[0]
+    assert "source-backed engine target" in joined
+    assert "Available Ichor expansions" in joined
+    assert "raw_turns:session-1" in joined
+    assert "Fresh tail: PR #138 benchmark is ready." in joined
+    assert "Stale middle user turn 3" not in joined
+    assert engine.get_status()["last_pack_metrics"]["llm_calls"] == 0
+    assert engine.get_status()["last_pack_metrics"]["api_calls"] == 0
+
+
+def test_ichor_context_engine_noop_turn_injects_no_pack_and_reads_nothing(monkeypatch) -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    engine = module.IchorContextEngine(fresh_tail_turns=4, max_pack_tokens=220)
+    engine.on_session_start("session-noop")
+
+    def forbidden_pack(**_kwargs):
+        raise AssertionError("no-op turn should not read/build Ichor context")
+
+    monkeypatch.setattr(engine, "_build_context_pack", forbidden_pack)
+    original = _long_messages("ok")
+
+    assembled = engine.compress(original, current_tokens=_estimate_tokens(original))
+    joined = "\n".join(str(m.get("content", "")) for m in assembled)
+
+    assert "<ichor-context" not in joined
+    assert "Available Ichor expansions" in joined
+    assert engine.get_status()["last_pack_metrics"] == {
+        "llm_calls": 0,
+        "api_calls": 0,
+        "db_reads": 0,
+        "db_writes": 0,
+        "tokens_estimated": 0,
+    }
+
+
+def test_ichor_context_engine_tools_expand_stored_raw_turns() -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    engine = module.IchorContextEngine(fresh_tail_turns=2)
+    engine.on_session_start("session-tools")
+    messages = _long_messages("Compare PR #138 tokens per turn.")
+    engine.compress(messages, current_tokens=_estimate_tokens(messages))
+
+    schemas = {schema["name"] for schema in engine.get_tool_schemas()}
+    assert {"ichor_status", "ichor_expand"}.issubset(schemas)
+
+    result = json.loads(engine.handle_tool_call(
+        "ichor_expand",
+        {"source_id": "raw_turns:session-tools:seq:1-3"},
+    ))
+    assert result["ok"] is True
+    assert "Original project goal" in result["content"]

--- a/tests/test_ichor_context_engine.py
+++ b/tests/test_ichor_context_engine.py
@@ -107,6 +107,20 @@ def test_ichor_context_engine_assembles_bounded_relevant_context(monkeypatch) ->
     assert engine.get_status()["last_pack_metrics"]["api_calls"] == 0
 
 
+def test_ichor_context_engine_unavailable_when_pack_builder_missing(monkeypatch) -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    monkeypatch.setattr(module, "build_context_pack", None)
+    monkeypatch.setattr(module, "_needs_memory_context", None)
+    engine = module.IchorContextEngine(fresh_tail_turns=4, max_pack_tokens=220)
+    engine.on_session_start("session-missing-pack")
+
+    assert engine.is_available() is False
+    assembled = engine.compress(_long_messages("Build Ichor context engine."))
+    joined = "\n".join(str(m.get("content", "")) for m in assembled)
+    assert "status=\"unavailable\"" not in joined
+    assert engine.get_status()["last_pack_metrics"]["db_reads"] == 0
+
+
 def test_ichor_context_engine_noop_turn_injects_no_pack_and_reads_nothing(monkeypatch) -> None:
     module = importlib.import_module("plugins.context_engine.ichor")
     engine = module.IchorContextEngine(fresh_tail_turns=4, max_pack_tokens=220)
@@ -148,3 +162,20 @@ def test_ichor_context_engine_tools_expand_stored_raw_turns() -> None:
     ))
     assert result["ok"] is True
     assert "Original project goal" in result["content"]
+
+
+def test_ichor_expand_caps_large_raw_turn_output() -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    engine = module.IchorContextEngine(fresh_tail_turns=2, max_expand_chars=1200)
+    engine.on_session_start("session-cap")
+    messages = _long_messages("Compare PR #138 tokens per turn.")
+    engine.compress(messages, current_tokens=_estimate_tokens(messages))
+
+    result = json.loads(engine.handle_tool_call(
+        "ichor_expand",
+        {"source_id": "raw_turns:session-cap:seq:1-40"},
+    ))
+    assert result["ok"] is True
+    assert result["truncated"] is True
+    assert result["omitted_chars"] > 0
+    assert len(result["content"]) <= 1200

--- a/tests/test_ichor_context_engine_turn_benchmark.py
+++ b/tests/test_ichor_context_engine_turn_benchmark.py
@@ -35,6 +35,8 @@ def test_turn_benchmark_shows_ichor_sends_fewer_tokens_per_turn(tmp_path: Path) 
     assert payload["mode"] == "ichor_context_engine_turn_benchmark"
     assert summary["rows_run"] >= 3
     assert summary["benchmark_ready"] is True
+    assert summary["baseline_label"] == "full transcript resend baseline until compressor threshold"
+    assert summary["token_estimate_method"] == "len_div_4_heuristic"
     assert summary["ichor_total_tokens"] < summary["default_total_tokens"]
     assert summary["ichor_avg_tokens_per_turn"] < summary["default_avg_tokens_per_turn"]
     assert summary["all_ichor_no_llm_api"] is True
@@ -57,6 +59,7 @@ def test_turn_benchmark_cli_writes_private_artifacts(tmp_path: Path) -> None:
 
     assert payload["mode"] == "ichor_context_engine_turn_benchmark"
     assert summary["benchmark_ready"] is True
+    assert summary["token_estimate_method"] == "len_div_4_heuristic"
     assert Path(payload["summary_path"]).exists()
     assert Path(payload["report_path"]).exists()
     assert artifact_dir.stat().st_mode & 0o777 == 0o700

--- a/tests/test_ichor_context_engine_turn_benchmark.py
+++ b/tests/test_ichor_context_engine_turn_benchmark.py
@@ -1,0 +1,62 @@
+"""Tests for IchorContextEngine per-turn token economy benchmark.
+
+These tests lock Thoth's course-correction marker into executable gates:
+benchmark the default-off IchorContextEngine on tokens sent per turn, not only
+post-threshold compression size. The benchmark must remain offline and must not
+flip profile/fleet defaults.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "benchmark-ichor-context-engine-turns.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("benchmark_ichor_context_engine_turns", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_turn_benchmark_shows_ichor_sends_fewer_tokens_per_turn(tmp_path: Path) -> None:
+    module = load_module()
+    payload = module.run_benchmark(tmp_path)
+    summary = payload["summary"]
+
+    assert payload["mode"] == "ichor_context_engine_turn_benchmark"
+    assert summary["rows_run"] >= 3
+    assert summary["benchmark_ready"] is True
+    assert summary["ichor_total_tokens"] < summary["default_total_tokens"]
+    assert summary["ichor_avg_tokens_per_turn"] < summary["default_avg_tokens_per_turn"]
+    assert summary["all_ichor_no_llm_api"] is True
+    assert summary["all_noop_rows_clean"] is True
+    assert summary["all_rows_have_expand_handles"] is True
+    assert summary["blockers"] == []
+
+
+def test_turn_benchmark_cli_writes_private_artifacts(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "turn-benchmark"
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--artifact-dir", str(artifact_dir), "--format", "json"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = json.loads(proc.stdout)
+    summary = payload["summary"]
+
+    assert payload["mode"] == "ichor_context_engine_turn_benchmark"
+    assert summary["benchmark_ready"] is True
+    assert Path(payload["summary_path"]).exists()
+    assert Path(payload["report_path"]).exists()
+    assert artifact_dir.stat().st_mode & 0o777 == 0o700

--- a/tests/test_ichor_raw_turns.py
+++ b/tests/test_ichor_raw_turns.py
@@ -1,0 +1,75 @@
+"""Tests for lossless Ichor raw-turn persistence."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from lib.ichor.raw_turns import RawTurnStore
+
+
+def _messages() -> list[dict[str, object]]:
+    return [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "Build the Ichor raw turn store."},
+        {
+            "role": "assistant",
+            "content": "Working.",
+            "tool_calls": [{"id": "call_1", "function": {"name": "search_files"}}],
+        },
+        {"role": "tool", "content": "tool result payload", "tool_call_id": "call_1", "name": "search_files"},
+    ]
+
+
+def test_raw_turn_store_migrate_is_idempotent(tmp_path: Path) -> None:
+    store = RawTurnStore(tmp_path / "ichor.db")
+
+    first = store.migrate()
+    second = store.migrate()
+
+    assert first["tables_ready"] == ["ichor_raw_turns", "ichor_session_frontier"]
+    assert second["tables_ready"] == ["ichor_raw_turns", "ichor_session_frontier"]
+    with sqlite3.connect(tmp_path / "ichor.db") as conn:
+        indexes = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index'").fetchall()
+        }
+    assert "idx_ichor_raw_turns_hash" in indexes
+    assert "idx_ichor_raw_turns_created" in indexes
+
+
+def test_raw_turn_store_ingests_lossless_idempotent_messages(tmp_path: Path) -> None:
+    store = RawTurnStore(tmp_path / "ichor.db")
+    messages = _messages()
+
+    first = store.ingest_messages("session-a", messages)
+    second = store.ingest_messages("session-a", messages)
+
+    assert first == {"seen": 4, "inserted": 4, "updated": 0, "last_seq": 3}
+    assert second == {"seen": 4, "inserted": 0, "updated": 0, "last_seq": 3}
+    rows = store.fetch_range("session-a", 1, 3)
+    assert [row.seq for row in rows] == [1, 2, 3]
+    assert rows[0].content == "Build the Ichor raw turn store."
+    assert rows[1].tool_name == "search_files"
+    assert rows[2].tool_call_id == "call_1"
+    assert json.loads(rows[2].message_json)["content"] == "tool result payload"
+    assert len(rows[2].content_hash) == 64
+    assert store.get_frontier("session-a") == {
+        "session_id": "session-a",
+        "last_ingested_seq": 3,
+        "active_tail_start_seq": 0,
+    }
+
+
+def test_raw_turn_store_updates_changed_seq_without_duplication(tmp_path: Path) -> None:
+    store = RawTurnStore(tmp_path / "ichor.db")
+    messages = _messages()
+    store.ingest_messages("session-a", messages)
+    changed = list(messages)
+    changed[1] = {"role": "user", "content": "Changed exact text."}
+
+    result = store.ingest_messages("session-a", changed)
+
+    assert result == {"seen": 4, "inserted": 0, "updated": 1, "last_seq": 3}
+    rows = store.fetch_range("session-a", 1, 1)
+    assert rows[0].content == "Changed exact text."


### PR DESCRIPTION
## Summary

Builds the default-off `IchorContextEngine` prototype requested by the Thoth course-correction marker, then finishes the remaining Fusion build item: optional lossless raw-turn persistence into Ichor.

This PR adds:

- `hermes-agent/plugins/context_engine/ichor/` — repo-shipped context engine plugin selected only by explicit `context.engine: ichor`.
- `IchorContextEngine` — bounded per-turn context selector that keeps a small fresh tail, injects Ichor context only when relevant, stores exact raw turns in memory by default, and exposes `ichor_status` / `ichor_expand` tools.
- `lib/ichor/raw_turns.py` — additive SQLite-backed raw-turn store with `ichor_raw_turns` and `ichor_session_frontier`; idempotent lossless ingest by `(session_id, seq)`; exact range expansion.
- `docs/fusion/ichor-context-engine-remaining-build.md` — Fusion Spec Contract for the remaining build slice.
- `scripts/benchmark-ichor-context-engine-turns.py` — tokens-per-turn benchmark comparing current full-transcript resend behavior before compressor threshold against the Ichor selector.
- Tests covering plugin loading, bounded assembly, no-op cleanliness, exact expansion, import-failure availability, expansion caps, optional persistent store behavior, store failure quietness, and tokens-per-turn measurement.

This intentionally does **not** re-enable hermes-lcm, change default `context.engine`, mutate live profile/fleet config, restart gateways, rotate live sessions, or claim the hybrid sidecar as final architecture.

Safety boundary:

- Default engine behavior still has no persistent raw-turn store configured, so it performs **zero live DB writes by default**.
- Persistence happens only when a `RawTurnStore` is explicitly supplied by tests/future default-off wiring.
- If raw-turn persistence fails, prompt assembly stays quiet: in-process expansion still works and the error is visible via `ichor_status`, not injected into the prompt.

Review polish applied:

- `is_available()` now reflects `lib.ichor.context_pack` importability.
- Missing context-pack import no longer injects an unavailable marker on every non-empty turn.
- `ichor_expand` output is capped with `truncated` / `omitted_chars` metadata.
- Benchmark labels the default arm as `full transcript resend baseline until compressor threshold`.
- Benchmark explicitly marks token totals as `len_div_4_heuristic`, not tokenizer-accurate absolute counts.

## Verification

RED/GREEN evidence:

- Initial engine RED: `tests/test_ichor_context_engine.py` failed because `plugins.context_engine.ichor` did not exist.
- Initial benchmark RED: `tests/test_ichor_context_engine_turn_benchmark.py` failed because `scripts/benchmark-ichor-context-engine-turns.py` did not exist.
- Remaining-build RED: `tests/test_ichor_raw_turns.py tests/test_ichor_context_engine.py` failed because `lib.ichor.raw_turns` did not exist.

Latest verification from `/tmp/pantheon-ichor-context-engine`:

- `PYTHONPATH=/tmp/pantheon-ichor-context-engine:/tmp/pantheon-ichor-context-engine/hermes-agent /usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/test_ichor_raw_turns.py tests/test_ichor_context_engine.py -q` → `13 passed`.
- `PYTHONPATH=/tmp/pantheon-ichor-context-engine:/tmp/pantheon-ichor-context-engine/hermes-agent /usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/test_ichor_context_pack.py tests/test_ichor_context_pack_canary.py tests/test_ichor_context_pack_rollout_simulation.py tests/test_ichor_compressor_weight_benchmark.py tests/test_ichor_context_engine.py tests/test_ichor_context_engine_turn_benchmark.py tests/test_ichor_raw_turns.py -q` → `43 passed`.
- `PYTHONPATH=/tmp/pantheon-ichor-context-engine:/tmp/pantheon-ichor-context-engine/hermes-agent /usr/local/lib/hermes-agent/venv/bin/python -m py_compile lib/ichor/raw_turns.py hermes-agent/plugins/context_engine/ichor/__init__.py tests/test_ichor_raw_turns.py tests/test_ichor_context_engine.py scripts/benchmark-ichor-context-engine-turns.py` → pass.
- `git diff --check` → pass.
- Static scan: no top-level debug `print()`, no bare `except:`, no hardcoded secrets.
- Artifact dir permission: `700 /tmp/ichor-context-engine-turn-benchmark-fusion-20260814T162148Z`.
- Independent code review before remaining-build slice: `passed: true`; suggestions applied in follow-up commit.

Benchmark artifact:

`/tmp/ichor-context-engine-turn-benchmark-fusion-20260814T162148Z/summary.json`

Benchmark verdict:

```json
{
  "all_ichor_no_llm_api": true,
  "all_no_runtime_mutation": true,
  "all_noop_rows_clean": true,
  "all_rows_have_expand_handles": true,
  "baseline_label": "full transcript resend baseline until compressor threshold",
  "benchmark_ready": true,
  "blockers": [],
  "default_avg_tokens_per_turn": 10534.67,
  "default_total_tokens": 221228,
  "ichor_avg_tokens_per_turn": 7116.19,
  "ichor_total_tokens": 149440,
  "rows_run": 3,
  "token_estimate_method": "len_div_4_heuristic",
  "tokens_saved": 71788,
  "tokens_saved_ratio": 0.3245,
  "turns_run": 21
}
```
