### PR TITLE
[verified] integrate Ichor context engine benchmark with main

### DIFF
--- a/conductor/scripts/profile-bootstrap-apply.py
+++ b/conductor/scripts/profile-bootstrap-apply.py
@@ -56,6 +56,10 @@ NO_CANON_REPORT = Path(
 TARGET_PROFILES = (
     "apollo", "cachyos", "hephaestus", "iris", "marvin", "rheta", "thoth",
 )
+CANARY_PROFILES = (
+    "ichor-canary",
+)
+ALLOWED_PROFILES = TARGET_PROFILES + CANARY_PROFILES
 SKILL_FILENAME = "SKILL.md"
 SKIP_PATH_COMPONENTS = (".archive",)
 DEFAULT_BACKUP_ROOT = PROFILES_ROOT / "_bootstrap-backups"
@@ -315,10 +319,10 @@ def main(argv: list[str] | None = None) -> int:
 
     # Resolve god filter
     if args.gods:
-        unknown = [g for g in args.gods if g not in TARGET_PROFILES]
+        unknown = [g for g in args.gods if g not in ALLOWED_PROFILES]
         if unknown:
             log_err(f"[error] unknown --god value(s): {unknown} "
-                    f"(allowed: {list(TARGET_PROFILES)})")
+                    f"(allowed: {list(ALLOWED_PROFILES)})")
             return 1
         profiles: tuple[str, ...] = tuple(args.gods)
     else:

--- a/docs/fusion/ichor-context-engine-remaining-build.md
+++ b/docs/fusion/ichor-context-engine-remaining-build.md
@@ -1,0 +1,104 @@
+# Fusion Spec Contract — IchorContextEngine Remaining Build
+
+## Objective
+
+Finish the remaining default-off `IchorContextEngine` build item: persist raw turns losslessly into an Ichor-owned SQLite store while preserving the v0 safety boundary.
+
+The current prototype keeps raw turns in process memory. That proves exact expansion handles inside one engine instance, but does not yet satisfy the architecture line from `docs/specs/ichor-precision-context-engine.md`:
+
+```text
+ingest every turn losslessly into Ichor
+→ maintain session frontier and fresh tail
+→ expose exact recall/expand tools for omitted context
+```
+
+## Files allowed
+
+Allowed to create/modify only:
+
+- `docs/fusion/ichor-context-engine-remaining-build.md`
+- `lib/ichor/raw_turns.py`
+- `hermes-agent/plugins/context_engine/ichor/__init__.py`
+- `tests/test_ichor_raw_turns.py`
+- `tests/test_ichor_context_engine.py`
+
+Do not touch live config, profile env, cron, gateway units, LCM plugin settings, or PR #138 benchmark files unless a test proves it is required.
+
+## Interfaces
+
+Create `lib.ichor.raw_turns` with:
+
+```python
+@dataclass(frozen=True)
+class RawTurn:
+    session_id: str
+    seq: int
+    role: str
+    content: str
+    content_hash: str
+    message_json: str
+    tool_name: str | None = None
+    tool_call_id: str | None = None
+    source: str = "context_engine"
+    created_at: str | None = None
+
+class RawTurnStore:
+    def __init__(self, db_path: str | Path) -> None: ...
+    def migrate(self) -> dict[str, object]: ...
+    def ingest_messages(self, session_id: str, messages: list[dict[str, Any]], *, source: str = "context_engine") -> dict[str, int]: ...
+    def fetch_range(self, session_id: str, start_seq: int, end_seq: int) -> list[RawTurn]: ...
+    def get_frontier(self, session_id: str) -> dict[str, Any] | None: ...
+```
+
+SQLite tables:
+
+```sql
+ichor_raw_turns(session_id, seq, role, content_hash, content, message_json, tool_name, tool_call_id, source, created_at, PRIMARY KEY(session_id, seq))
+ichor_session_frontier(session_id PRIMARY KEY, last_ingested_seq, active_tail_start_seq, updated_at)
+```
+
+`ingest_messages()` must be idempotent by `(session_id, seq)` and must not duplicate repeated calls with the same message list.
+
+Update `IchorContextEngine`:
+
+- accepts optional `raw_turn_store: RawTurnStore | None`
+- default remains `None` so the prototype does not mutate live DB by default
+- `_ingest_raw_turns()` always keeps in-process rows and also writes to `raw_turn_store` if configured
+- `ichor_expand` first checks in-process rows, then falls back to `raw_turn_store.fetch_range()` if available
+- `get_status()` exposes raw-turn storage metrics: configured/persisted count/frontier or last error
+- no LLM/API calls; no fleet/profile/default changes
+
+## Constraints
+
+- Strict TDD: write tests that fail before implementation.
+- No top-level debug `print()` in Python files.
+- No bare `except:`.
+- No live DB writes in tests; use temp DB paths only.
+- No config/fleet/LCM changes.
+- Preserve existing benchmark verdict shape unless new storage metrics are additive.
+- If SQLite write fails, fail quiet for prompt assembly: keep in-process expansion working and report error in status; do not inject panic context into the live prompt.
+
+## Verification
+
+Commands must pass from `/tmp/pantheon-ichor-context-engine`:
+
+```bash
+PYTHONPATH=/tmp/pantheon-ichor-context-engine:/tmp/pantheon-ichor-context-engine/hermes-agent /usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/test_ichor_raw_turns.py tests/test_ichor_context_engine.py -q
+PYTHONPATH=/tmp/pantheon-ichor-context-engine:/tmp/pantheon-ichor-context-engine/hermes-agent /usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/test_ichor_context_pack.py tests/test_ichor_context_pack_canary.py tests/test_ichor_context_pack_rollout_simulation.py tests/test_ichor_compressor_weight_benchmark.py tests/test_ichor_context_engine.py tests/test_ichor_context_engine_turn_benchmark.py tests/test_ichor_raw_turns.py -q
+PYTHONPATH=/tmp/pantheon-ichor-context-engine:/tmp/pantheon-ichor-context-engine/hermes-agent /usr/local/lib/hermes-agent/venv/bin/python -m py_compile lib/ichor/raw_turns.py hermes-agent/plugins/context_engine/ichor/__init__.py tests/test_ichor_raw_turns.py tests/test_ichor_context_engine.py
+git diff --check
+```
+
+Also run a static scan for:
+
+- top-level `print(` outside `if __name__ == "__main__"`
+- bare `except:`
+- hardcoded token/API-key patterns
+
+## Expected result
+
+A stacked follow-up on PR #139 proving the remaining build item:
+
+```text
+IchorContextEngine can persist raw turns losslessly to Ichor when explicitly configured, while default-off operation still performs zero live DB writes.
+```

--- a/docs/ichor-context-pack-canary.md
+++ b/docs/ichor-context-pack-canary.md
@@ -1,0 +1,122 @@
+# Ichor Context-Pack Canary Plan
+
+This document defines the next gate after the dry-run/manual context-pack surface. It is intentionally **replay-only** until Konan explicitly approves a disposable live-profile canary.
+
+## Status
+
+Implemented on branch `feature/ichor-context-pack-canary-harness`:
+
+- `scripts/replay-ichor-context-pack-canary.py` — replay-only matrix runner and report generator.
+- `tests/test_ichor_context_pack_canary.py` — safety, quality, artifact, and documentation contract tests.
+- This document — operator plan, non-goals, readiness gate, and rollback contract.
+
+## Non-goals
+
+This branch does **not** enable live context injection.
+
+Hard non-goals:
+
+- No live profile mutation.
+- No gateway restart.
+- No LCM enablement.
+- No compressor engine replacement.
+- No session rotation.
+- No transcript rewrite.
+- No config edit.
+- No automatic production enablement.
+
+The harness can write only scratch artifacts under the requested artifact directory, normally `/tmp/ichor-context-pack-canary-<UTC>/`.
+
+## Replay-only matrix
+
+The canary harness runs representative dry-run rows across:
+
+- `hermes / ops` operator follow-up questions about the context-pack work itself.
+- `hephaestus / debug` and `thoth / research` golden `Conductor v2` role-aware queries.
+- `rheta / copywriting` pricing-copy context.
+- `hermes` and `thoth` LCM/risk recall.
+- casual/no-op chat rows for `hermes`, `thoth`, and `hephaestus`.
+
+Each row records:
+
+- coverage status and returned source count
+- source titles and source paths
+- injectable context size
+- token estimate
+- wall time
+- DB reads and writes
+- LLM/API call counts
+- mutation safety flags
+- comparison against the cheap default-compressor baseline
+
+## Readiness gate
+
+The summary has three separate verdicts:
+
+- `safety_pass` — dry-run invariants only.
+- `quality_pass` — source grounding, role coverage, and no-op behavior.
+- `canary_ready` — true only when both safety and quality pass.
+
+Safety requires:
+
+- `llm_calls == 0`
+- `api_calls == 0`
+- `db_writes == 0`
+- all runtime mutation flags false
+
+Quality requires:
+
+- operator follow-up rows return source-backed context
+- high-priority golden rows return source-backed context
+- source grounding improves over the default-compressor baseline
+- casual/no-op rows return no injectable context, zero tokens, and zero DB reads
+
+## Rollback contract
+
+Because this branch is replay-only, rollback is deletion of scratch artifacts and abandoning the branch/PR.
+
+If a future Konan-approved disposable live-profile canary exists, rollback must be documented in that future PR as:
+
+1. revert exactly one disposable profile config diff
+2. restart only that disposable profile gateway
+3. verify no LCM plugin/config change exists
+4. verify default compressor remains the fleet default
+5. preserve the replay report proving why the canary was stopped
+
+## Operator commands
+
+Run the replay harness from the worktree root:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-canary \
+/usr/local/lib/hermes-agent/venv/bin/python \
+  scripts/replay-ichor-context-pack-canary.py \
+  --artifact-dir /tmp/ichor-context-pack-canary-manual \
+  --format json
+```
+
+Markdown report mode:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-canary \
+/usr/local/lib/hermes-agent/venv/bin/python \
+  scripts/replay-ichor-context-pack-canary.py \
+  --artifact-dir /tmp/ichor-context-pack-canary-manual \
+  --format markdown
+```
+
+Expected artifact files:
+
+- `summary.json`
+- `report.md`
+- one `<case_id>.json` file per replay row
+
+Expected current verdict:
+
+```text
+safety_pass: true
+quality_pass: true
+canary_ready: true
+```
+
+That verdict means **ready to discuss a disposable-profile canary**, not ready for fleet enablement.

--- a/docs/ichor-context-pack-dry-run.md
+++ b/docs/ichor-context-pack-dry-run.md
@@ -1,0 +1,171 @@
+# Ichor Context-Pack Dry-Run Operator Notes
+
+This branch adds a bounded, source-backed context-pack builder for Ichor. It is intentionally **manual / dry-run only** until Konan explicitly approves canary or live wiring.
+
+## Status
+
+Implemented on branch `feature/ichor-context-pack-dry-run`:
+
+- `lib/ichor/context_pack.py` — pure builder that returns compact, source-linked context packs.
+- `scripts/dry-run-ichor-context-pack.py` — operator CLI for benchmark and comparison output.
+- `lib/ichor_mcp.py` — MCP/manual tool surface named `ichor_context_pack`.
+- `tests/test_ichor_context_pack.py` and `tests/test_ichor_mcp.py` — golden-query, no-op, MCP, budget, and safety contracts.
+
+## Safety guarantees
+
+The context-pack path is deliberately constrained:
+
+- No LLM calls.
+- No external API calls.
+- No runtime mutation.
+- No session rotation.
+- No transcript rewrite.
+- No config edits.
+- No gateway restart.
+- No LCM enablement.
+- No DB writes in the builder metrics path.
+- No MCP audit DB write for `ichor_context_pack` dry-run calls.
+
+The MCP wrapper forces `dry_run=True` internally and does not expose a public `dry_run` / live-mode parameter.
+
+Public MCP budgets are clamped before the builder runs:
+
+- `max_items`: 1–8
+- `max_tokens`: 1–900
+- `max_ms`: 1–350
+
+Invalid or non-finite budget values fall back to safe defaults.
+
+## CLI usage
+
+Run from the Pantheon repo/worktree root:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run \
+python3 scripts/dry-run-ichor-context-pack.py \
+  --god thoth \
+  --phase research \
+  --query "Conductor v2" \
+  --max-items 8 \
+  --compare-default-compressor \
+  --format json
+```
+
+Markdown output is also available:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run \
+python3 scripts/dry-run-ichor-context-pack.py \
+  --god hephaestus \
+  --phase debug \
+  --query "Conductor v2" \
+  --max-items 8 \
+  --format markdown
+```
+
+Expected safety fields in dry-run output:
+
+```json
+{
+  "would_mutate_runtime": false,
+  "would_rotate_session": false,
+  "would_rewrite_transcript": false,
+  "would_change_config": false,
+  "would_restart_gateway": false
+}
+```
+
+## MCP/manual tool usage
+
+The standalone MCP server manifest should include `ichor_context_pack`:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run \
+python3 lib/ichor_mcp.py --list-tools
+```
+
+Direct manual smoke:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run python3 - <<'PY'
+import json
+from lib import ichor_mcp
+
+pack = json.loads(ichor_mcp.ichor_context_pack(
+    query="Conductor v2",
+    god_name="thoth",
+    phase="research",
+    max_items=8,
+))
+print(json.dumps({
+    "coverage": pack["coverage"],
+    "metrics": pack["metrics"],
+}, indent=2, sort_keys=True))
+PY
+```
+
+Expected invariant highlights:
+
+- `metrics.mode == "dry_run"`
+- `metrics.llm_calls == 0`
+- `metrics.api_calls == 0`
+- `metrics.db_writes == 0`
+- returned pack includes `injectable_context` and source links when coverage is available
+
+## Operator follow-up recall smoke
+
+This branch also covers real operator follow-up questions about the context-pack work itself, not only canned golden-query examples:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run \
+python3 scripts/dry-run-ichor-context-pack.py \
+  --god hermes \
+  --phase ops \
+  --query "where did we leave the Ichor context pack?" \
+  --max-items 8 \
+  --compare-default-compressor \
+  --format json
+```
+
+Expected highlights:
+
+- `candidate_context_pack.coverage.status == "ok"`
+- context mentions dry-run/manual promotion discipline
+- context repeats the no-LCM/no-runtime-mutation guard
+- context names the canary gate before live use
+- `candidate_context_pack.metrics.llm_calls == 0`
+- `candidate_context_pack.metrics.api_calls == 0`
+- `candidate_context_pack.metrics.db_writes == 0`
+
+
+## Verification recipe
+
+Use the Hermes Agent venv when this host's `/bin/python3` lacks pytest:
+
+```bash
+PYTHONPATH=/home/konan/pantheon-ichor-context-pack-dry-run:$PYTHONPATH \
+/usr/local/lib/hermes-agent/venv/bin/python -m pytest \
+  tests/test_ichor_context_pack.py \
+  tests/test_ichor_mcp.py \
+  -q
+```
+
+Current expected result after the operator-follow-up recall gate:
+
+```text
+29 passed
+```
+
+## Canary/live wiring gate
+
+This branch does **not** enable the context pack in the live compressor/session path.
+
+Do not change any of these without explicit Konan approval:
+
+- `context.engine`
+- profile or fleet `compression.*`
+- live god gateway process state
+- LCM plugin/config state
+- automatic context injection path
+
+Recommended next step after PR review is a separate canary plan for one god/profile with rollback, metrics, and a live proof gate.

--- a/docs/specs/ichor-compressor-weight-benchmark.md
+++ b/docs/specs/ichor-compressor-weight-benchmark.md
@@ -1,0 +1,42 @@
+# Ichor Compressor-Weight Benchmark — Spec Contract
+
+## Source handoff
+
+Original handoff: `~/athenaeum/Codex-Pantheon/design/ichor-context-pack-compressor-augmentation.md`.
+
+This work implements the missing Phase 0/2 measurement gate. It does **not** enable live context-pack injection, change `context.engine`, restart gateways, rotate sessions, or re-enable Hermes LCM.
+
+## Problem
+
+The existing replay and rollout-simulation gates prove that the Ichor context pack can add source-backed recall context safely. They do **not** prove compressor-weight behavior because their default-compressor baseline usually evaluates tiny prompts where `ContextCompressor.should_compress()` is false.
+
+The benchmark must exercise a long transcript where Hermes' built-in `ContextCompressor` really has a compressible middle window and then compare that baseline against Ichor context-pack augmentation metrics.
+
+## Acceptance gates
+
+For each benchmark case:
+
+1. Default compressor baseline is available.
+2. Long transcript estimated tokens exceed the compressor threshold.
+3. `ContextCompressor.has_content_to_compress(messages)` is true.
+4. The benchmark calls `ContextCompressor.compress(...)` on a copied fixture with a deterministic fake summary path, so no provider/API call is made.
+5. Default compression reduces token estimate and message count.
+6. Ichor context-pack build has `llm_calls == 0`, `api_calls == 0`, `db_writes == 0`.
+7. Ichor context pack stays within `max_pack_tokens`.
+8. Safety flags stay false: no runtime mutation, session rotation, transcript rewrite, config edit, or gateway restart.
+9. No-op benchmark row stays zero-read/zero-injection.
+10. Benchmark writes JSON summary + markdown report artifacts.
+
+## Compared modes
+
+- `default_compressor`: built-in `ContextCompressor.compress()` on a synthetic long transcript with deterministic fake summarization.
+- `ichor_context_pack`: current Ichor selector/pack builder.
+- `hybrid_projection`: default compressed context plus bounded Ichor pack token overhead; this is a measurement projection only, not live wiring.
+
+## Out of scope
+
+- Live profile canary.
+- New context engine plugin.
+- Fleet defaults.
+- Hermes LCM re-enable.
+- Real LLM/API compression calls.

--- a/docs/specs/ichor-precision-context-engine.md
+++ b/docs/specs/ichor-precision-context-engine.md
@@ -1,0 +1,289 @@
+# Ichor Precision Context Engine — Reference Design
+
+## Purpose
+
+The product goal is not to make lossy context compaction better. The goal is to make routine context compaction unnecessary by changing Hermes from an ever-growing live transcript into a bounded, memory-backed context selector.
+
+Current Hermes shape:
+
+```text
+append every turn to live messages
+→ live prompt grows
+→ hit threshold
+→ ContextCompressor summarizes/drops old middle
+→ keep sending large active context until the next compaction
+```
+
+Target Ichor shape:
+
+```text
+ingest every turn losslessly into Ichor
+→ maintain session frontier and fresh tail
+→ classify the current turn
+→ select only context needed for this turn
+→ expose exact recall/expand tools for anything omitted
+→ send a small source-backed prompt
+```
+
+This makes Ichor the memory substrate and `IchorContextEngine` the compressor-replacement surface. The `compress()` method still satisfies Hermes' `ContextEngine` interface, but internally it means **memory promotion plus bounded active-context assembly**, not lossy summarization.
+
+## Non-goals
+
+- Do not re-enable the separate Hermes-LCM plugin fleet-wide.
+- Do not keep injecting a static context pack forever.
+- Do not summarize raw truth into authority; summaries are derived views only.
+- Do not rely on large prompt windows as the primary memory strategy.
+- Do not mutate live profile/fleet config until default-off benchmarks prove the engine.
+
+## Operating invariants
+
+1. **Raw turns are authoritative.** Every user, assistant, tool-call, and tool-result message is stored losslessly with source metadata and content hashes.
+2. **Active prompt is bounded every turn.** The model should receive only the current request, a small fresh tail, active frontier state, and relevant selected memory.
+3. **No-op turns stay cheap.** If the current turn does not need stored context, inject nothing beyond the fresh tail and stable system/user rules.
+4. **Derived context is source-backed.** Decisions, constraints, files, and summaries point back to exact raw turns or canonical source files.
+5. **Exact expansion is available on demand.** Omitted context can be recalled by handle/source id via `ichor_recall`, `ichor_expand`, or `ichor_inspect`.
+6. **Fresh user intent wins.** Recent user instructions and current task state outrank older summaries or stale memory.
+7. **Fallback preserves safety.** If Ichor selection fails, preserve fresh tail and fall back to default compressor or unchanged messages according to configured mode.
+
+## Per-turn context assembly pipeline
+
+### 0. Inputs
+
+Each turn starts with:
+
+- full in-process message list supplied by Hermes
+- current user message
+- session id / platform thread id
+- tool schemas available to this session
+- token budget from model metadata
+- Ichor session frontier state
+
+### 1. Lossless turn ingestion
+
+Before selection, persist any new messages since the last frontier:
+
+```text
+raw_turns(session_id, seq, role, content_hash, content, source, tool_name, timestamps)
+raw_tool_results(session_id, seq, tool_call_id, tool_name, status, content_hash, content)
+```
+
+Cost control:
+
+- append-only writes
+- content hash dedupe for repeated tool output
+- store large tool results by blob reference, not repeatedly inline
+- batch writes once per turn, not per selector phase
+- avoid LLM extraction on the hot path
+
+### 2. Frontier update
+
+Maintain a compact session frontier:
+
+```text
+session_id
+last_ingested_seq
+active_tail_start_seq
+last_selected_context_ids
+current_task_id
+current_topic_hash
+fresh_tail_count
+turn_count_since_topic_shift
+```
+
+The frontier says what can be omitted from the live prompt because it is safely stored and recallable.
+
+### 3. Cheap current-turn classification
+
+Use deterministic first-pass classifiers before any semantic/vector work:
+
+- command shape: build / compare / summarize / debug / recall / casual
+- topic shift vs continuation
+- named entities: repo, branch, PR, file path, god, service, endpoint, artifact path
+- explicit references: “that”, “this”, “the benchmark”, “PR #138”, “continue”
+- safety-sensitive intent: config change, gateway restart, destructive op, credential work
+
+Cost control:
+
+- regex/path/entity extraction first
+- only use vector search when lexical/entity confidence is low
+- no LLM call for routine classification
+- cache classification result by current-message hash
+
+### 4. Candidate memory retrieval
+
+Build a candidate set from multiple cheap lanes, in priority order:
+
+1. **Pinned active state** — current todos, current branch/PR/artifact, latest user directive.
+2. **Fresh tail references** — entities mentioned in the last N turns.
+3. **Exact lexical matches** — file paths, PR ids, branch names, artifact names, service names.
+4. **Ichor facts/events/decisions** — source-backed facts scoped to the current task/god/project.
+5. **Vector/semantic recall** — only if lexical/entity lanes do not satisfy coverage.
+6. **Raw-turn handles** — include handles for expansion, not full raw text unless required.
+
+Cost control:
+
+- hard cap rows examined per lane
+- stop early when coverage is sufficient
+- prefer structured indexed rows over raw transcript scans
+- negative cache known no-op/casual queries
+- per-session hot cache for recently selected context ids
+
+### 5. Relevance scoring and pruning
+
+Score candidates with a cheap weighted model:
+
+```text
+score = recency
+      + explicit_reference_match
+      + entity_overlap
+      + active_task_match
+      + source_authority
+      + user_directive_priority
+      - stale_topic_penalty
+      - already_in_fresh_tail_penalty
+      - large_payload_penalty
+```
+
+Then prune by:
+
+- relevance threshold
+- token budget
+- diversity across categories: decisions, constraints, files, artifacts, risks
+- source freshness
+- contradiction handling: newer source-backed items outrank older summaries
+
+### 6. Assemble bounded prompt sections
+
+The engine returns a valid OpenAI-format message list containing:
+
+```text
+1. system/developer prompt layers already required by Hermes
+2. stable user profile / durable preferences
+3. current task frontier brief, if any
+4. fresh tail: small number of recent raw turns
+5. selected Ichor context pack: only relevant source-backed items
+6. exact recall handles for omitted-but-available context
+7. current user message
+```
+
+Recommended initial budgets:
+
+```text
+fresh_tail: 4–8 turns, dynamically reduced for tool-heavy sessions
+frontier_brief: <= 250 tokens
+selected_memory_pack: <= 600–900 tokens
+recall_handles: <= 150 tokens
+tool-result inline budget: <= 1,000 tokens unless current turn directly needs it
+```
+
+### 7. Exact expansion tools
+
+If the model lacks enough detail, it should call tools instead of receiving everything upfront:
+
+```text
+ichor_status(session_id)
+ichor_recall(query, scope, max_items)
+ichor_expand(source_id | raw_turn_range | artifact_id)
+ichor_inspect(frontier | selected_context | omitted_context)
+```
+
+The prompt should include handles like:
+
+```text
+Available expansions:
+- raw_turns:session:123:seq:80-94 — PR #138 benchmark build loop
+- artifact:/tmp/ichor-compressor-weight-benchmark-ready-reviewfix.../summary.json
+- decision:ichor-context-engine-target
+```
+
+not the full historical text.
+
+## Low-token strategy
+
+1. **Do not send stored history by default.** Store it, index it, and pass handles.
+2. **Use a small fresh tail.** Most turn coherence comes from the last few exchanges, not the full thread.
+3. **Summaries are optional views, not mandatory prompt cargo.** If a summary is not relevant to the current turn, omit it.
+4. **Prefer facts over prose.** A 40-token source-backed decision beats a 500-token paragraph.
+5. **Prefer handles over payloads.** Send `expand_id` unless exact text is immediately necessary.
+6. **Elide duplicated tool output.** If a tool result is already stored and not needed verbatim, include only status/hash/path.
+7. **No-op suppression.** Casual acknowledgements and broad planning pivots should not pull database context unless entities match.
+8. **Budget by category.** No single lane gets to consume the whole context window.
+
+## Low-resource strategy
+
+1. **Hot path is deterministic.** Regex/entity/path extraction and indexed lookup happen before vector or LLM work.
+2. **Use SQLite/FTS/entity indexes first.** Chroma/vector search is a fallback, not default per turn.
+3. **Batch writes.** One append transaction per turn.
+4. **Deduplicate blobs by content hash.** Large repeated tool outputs are stored once.
+5. **Cache selected packs.** Reuse when current-message/topic hash and frontier are unchanged.
+6. **Bound all loops.** Max rows examined, max source expansions, max wall time.
+7. **Degrade gracefully.** If retrieval exceeds budget, return fresh tail + handles, not a huge panic pack.
+8. **Async extraction.** Expensive entity/relationship extraction can happen after the response as background enrichment.
+
+## Minimal viable `IchorContextEngine`
+
+```text
+class IchorContextEngine(ContextEngine):
+    name = "ichor"
+
+    on_session_start:
+      load/create frontier
+
+    should_compress:
+      return True when live messages exceed active-tail budget OR frontier needs advancement
+
+    compress:
+      ingest new raw turns
+      classify current turn
+      retrieve/prune selected memory
+      assemble bounded messages
+      save frontier
+      return bounded OpenAI-format messages
+
+    get_tool_schemas:
+      expose ichor_status / ichor_recall / ichor_expand / ichor_inspect
+
+    handle_tool_call:
+      execute exact recall/expand against Ichor source records
+```
+
+## Benchmark acceptance for replacement
+
+The replacement benchmark must measure per-turn prompt economy, not only after-threshold compression.
+
+Compare:
+
+```text
+A: current Hermes transcript accumulation + default compressor
+B: Ichor context-pack sidecar
+C: IchorContextEngine selector
+D: hybrid fallback
+```
+
+Required metrics:
+
+- tokens sent per turn
+- cumulative tokens sent over a task
+- retained decision/constraint correctness
+- source-grounding rate
+- missed-context rate
+- stale-context injection rate
+- no-op injection rate
+- latency and rows examined
+- DB reads/writes
+- LLM/API calls
+- fallback behavior
+
+Win condition:
+
+```text
+IchorContextEngine sends materially fewer tokens per turn than default transcript accumulation while preserving or improving task correctness and source grounding.
+```
+
+## Rollout path
+
+1. Keep PR #138 as the augmentation/benchmark proof.
+2. Build `IchorContextEngine` default-off behind explicit config.
+3. Run per-turn token economy benchmark on long realistic sessions.
+4. Canary only one disposable profile after benchmark win.
+5. Promote to broader profiles only after rollback and no-op behavior are proven.

--- a/lib/ichor/context_pack.py
+++ b/lib/ichor/context_pack.py
@@ -1,0 +1,782 @@
+"""Pure Ichor context-pack builder.
+
+Phase 1 intentionally stays small: deterministic source-backed selection,
+no LLM/API calls, no DB writes, and graceful degradation when live Ichor data
+is unavailable.
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+import time
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable
+
+
+ATHENAEUM = Path("/home/konan/athenaeum")
+ICHOR_DB = Path.home() / ".hermes" / "ichor.db"
+
+PRIMARY_SECTIONS = (
+    "current_decisions",
+    "hard_constraints",
+    "relevant_files",
+    "risks",
+    "related_entities",
+    "recent_changes",
+)
+ROLE_TAGS = {"hephaestus", "thoth", "rheta"}
+MEMORY_TRIGGER_TERMS = {
+    "athenaeum",
+    "canary",
+    "compress",
+    "conductor",
+    "context",
+    "decide",
+    "decision",
+    "god",
+    "gods",
+    "ichor",
+    "infrastructure",
+    "lcm",
+    "managed",
+    "pantheon",
+    "pricing",
+    "retainer",
+    "session",
+    "workflow",
+}
+
+
+@dataclass(frozen=True)
+class Anchor:
+    section: str
+    title: str
+    text: str
+    source_path: str
+    source_id: str
+    tags: tuple[str, ...]
+    priority: int = 50
+
+
+ANCHORS: tuple[Anchor, ...] = (
+    Anchor(
+        section="current_decisions",
+        title="Conductor v2 canonical reaction engine",
+        text=(
+            "Conductor v2 shipped as the canonical reaction engine; v1 stays "
+            "retired. The implementation is a single-process daemon wired by "
+            "engine, gateway, nats, webhook, delivery, and a service entry."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/decisions/2026-06-14-conductor-v2.md",
+        source_id="conductor-v2-built-tested-deployed",
+        tags=("conductor", "v2", "workflow", "nats", "systemd", "hephaestus", "debug"),
+        priority=95,
+    ),
+    Anchor(
+        section="relevant_files",
+        title="Conductor v2 runtime files and endpoints",
+        text=(
+            "Runtime evidence names conductor/v2/engine.py, service.py, "
+            "api_server.py, delivery.py, nats.py, webhook.py, cron_scheduler.py, "
+            "the /health endpoint, and the Thoth gateway on :8642."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/briefs/2026-06-23-pantheon-vs-hermes-344.md",
+        source_id="pantheon-vs-hermes-344-workflow-dag-engine",
+        tags=("conductor", "v2", "endpoint", "nats", "mcp", "hephaestus", "debug"),
+        priority=92,
+    ),
+    Anchor(
+        section="hard_constraints",
+        title="Systemd service is part of the deployed Conductor v2 seam",
+        text=(
+            "The Conductor v2 deployment record points to the systemd unit "
+            "at ~/.config/systemd/user/conductor-v2.service and records a live "
+            "smoke test with daemon start, /health 200, gateway connection, and "
+            "webhook event quarantine behavior."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/decisions/2026-06-14-conductor-v2.md",
+        source_id="conductor-v2-systemd-smoke-test",
+        tags=("conductor", "v2", "systemd", "endpoint", "hephaestus", "debug"),
+        priority=90,
+    ),
+    Anchor(
+        section="related_entities",
+        title="MCP and cross-platform messaging surface",
+        text=(
+            "Pantheon exposes dynamic registration through MCP tools and uses "
+            "NATS/Subspace subjects for cross-Pantheon routing, including "
+            "subspace outgoing and incoming patterns."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/briefs/2026-06-23-pantheon-vs-hermes-344.md",
+        source_id="pantheon-vs-hermes-344-agent-comms",
+        tags=("conductor", "v2", "mcp", "nats", "routing", "hephaestus", "debug"),
+        priority=88,
+    ),
+    Anchor(
+        section="current_decisions",
+        title="Workflow validator and cross-god dispatch model",
+        text=(
+            "Conductor workflows are validated at load time; workflow records "
+            "and routing decisions cover cross-god handoffs, production YAML, "
+            "and the workflow catalog."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/DECISIONS.md",
+        source_id="workflow-validator-cross-god-routing",
+        tags=("conductor", "v2", "workflow", "cross-god", "routing", "thoth", "research"),
+        priority=96,
+    ),
+    Anchor(
+        section="relevant_files",
+        title="Pantheon workflow architecture",
+        text=(
+            "The workflow engine is Pantheon's runtime for executing multi-god "
+            "task pipelines. Workflows are directed graphs stored as JSON and "
+            "made available from the workflow launcher."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/constitution/WORKFLOWS.md",
+        source_id="constitution-workflows-runtime",
+        tags=("conductor", "v2", "workflow", "cross-god", "routing", "thoth", "research"),
+        priority=93,
+    ),
+    Anchor(
+        section="related_entities",
+        title="Zeus routing and cross-god handoff",
+        text=(
+            "Pantheon architecture assigns routing and handoffs to the harness "
+            "layer; Zeus evaluates candidate gods and returns routing options "
+            "with reasoning."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/constitution/SANCTUARY.md",
+        source_id="sanctuary-zeus-routing",
+        tags=("conductor", "v2", "workflow", "cross-god", "routing", "thoth", "research"),
+        priority=91,
+    ),
+    Anchor(
+        section="current_decisions",
+        title="Pantheon $5k managed offer",
+        text=(
+            "Pantheon pricing context repeatedly frames the offer as a $5k/mo "
+            "managed multi-agent AI system for local professional services."
+        ),
+        source_path="/home/konan/athenaeum/Codex-God-thoth/research/lead-funnel-2026-05-23/sub_conversion-optimization.md",
+        source_id="pantheon-5k-managed-offer",
+        tags=("pantheon", "pricing", "$5k", "managed", "rheta", "copywriting"),
+        priority=96,
+    ),
+    Anchor(
+        section="hard_constraints",
+        title="Managed dedicated infrastructure lane",
+        text=(
+            "For pricing copy, position the managed offer around dedicated "
+            "infrastructure and a concrete $5k monthly commitment, not a "
+            "self-hosted or no-subscription lane."
+        ),
+        source_path="/home/konan/athenaeum/Codex-God-thoth/research/lead-funnel-2026-05-23/sub_funnel-design.md",
+        source_id="pantheon-dedicated-infrastructure-pricing-lane",
+        tags=("pantheon", "pricing", "$5k", "managed", "dedicated", "infrastructure", "rheta", "copywriting"),
+        priority=94,
+    ),
+    Anchor(
+        section="current_decisions",
+        title="Ichor context pack remains dry-run/manual before promotion",
+        text=(
+            "The Ichor context-pack design says not to replace the default "
+            "compressor first: keep the fleet on the built-in compressor, build "
+            "a bounded dry-run/manual augmentation, and promote only after "
+            "benchmarks prove default-compressor-weight behavior."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/design/ichor-context-pack-compressor-augmentation.md",
+        source_id="ichor-context-pack-dry-run-manual-before-promotion",
+        tags=("ichor", "context", "pack", "compressor", "dry", "run", "dry-run", "manual", "canary", "lcm", "hermes", "ops"),
+        priority=98,
+    ),
+    Anchor(
+        section="hard_constraints",
+        title="Context pack safety gates block LCM-style runtime mutation",
+        text=(
+            "The design explicitly avoids the hermes-lcm failure mode: no "
+            "resident per-session DAG or index, no transcript rewrite, no "
+            "session rotation, no config mutation, no gateway restart, and no "
+            "live context-engine replacement before canary sign-off."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/design/ichor-context-pack-compressor-augmentation.md",
+        source_id="ichor-context-pack-safety-gates-no-lcm-runtime-mutation",
+        tags=("ichor", "context", "pack", "compressor", "dry", "run", "dry-run", "manual", "canary", "lcm", "runtime", "mutation", "hermes", "ops"),
+        priority=97,
+    ),
+    Anchor(
+        section="risks",
+        title="Canary only after source-grounding and weight benchmarks",
+        text=(
+            "Before live profile use, the context pack must run golden queries, "
+            "long-history replay, source-grounding comparisons against the "
+            "default compressor, prompt-cache checks, and rollback proof for a "
+            "single disposable canary profile."
+        ),
+        source_path="/home/konan/athenaeum/Codex-Pantheon/design/ichor-context-pack-compressor-augmentation.md",
+        source_id="ichor-context-pack-canary-gates-before-live-use",
+        tags=("ichor", "context", "pack", "compressor", "canary", "benchmark", "source", "grounding", "rollback", "hermes", "ops"),
+        priority=96,
+    ),
+)
+
+
+def _rss_kb() -> int | None:
+    try:
+        for line in Path("/proc/self/status").read_text(encoding="utf-8").splitlines():
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1])
+    except (OSError, IndexError, ValueError):
+        return None
+    return None
+
+
+def _estimate_tokens_text(text: str) -> int:
+    return max(1, (len(text) + 3) // 4) if text else 0
+
+
+def _terms(*parts: str) -> set[str]:
+    words: set[str] = set()
+    for part in parts:
+        for raw in part.lower().replace("/", " ").replace("-", " ").split():
+            word = raw.strip(".,:;()[]{}'\"`")
+            if len(word) > 1:
+                words.add(word)
+    return words
+
+
+def _sanitize_fts(query: str) -> str:
+    """Sanitize user text for SQLite FTS5 MATCH syntax."""
+    cleaned = re.sub(r'[":*()\^\-]', " ", query or "")
+    cleaned = re.sub(r"\b(AND|OR|NOT|NEAR)\b", " ", cleaned, flags=re.IGNORECASE)
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _needs_memory_context(query: str, god_name: str, phase: str, task_type: str) -> bool:
+    """Cheap no-read classifier: casual turns avoid DB and prompt growth.
+
+    God and role labels are ranking hints, not memory-need signals. A casual
+    chat turn should not become a DB read just because the active profile is
+    named ``thoth`` or ``hephaestus``.
+    """
+    del god_name, phase
+    terms = _terms(query, task_type)
+    return bool(terms & MEMORY_TRIGGER_TERMS)
+
+
+@lru_cache(maxsize=64)
+def _source_file_info(source_path: str, tags: tuple[str, ...]) -> tuple[bool, str]:
+    """Return existence + compact excerpt for a source file.
+
+    Source files are stable during one dry-run/manual build, so caching avoids
+    repeated full-file reads and keeps the pack builder compressor-weight.
+    """
+    path = Path(source_path)
+    if not path.exists():
+        return False, ""
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return False, ""
+
+    lowered_tags = [tag.lower() for tag in tags[:4] if tag]
+    first_nonempty = ""
+    for line in lines:
+        clean = line.strip()
+        if clean and not first_nonempty:
+            first_nonempty = clean[:360]
+        lower = clean.lower()
+        if clean and any(tag in lower for tag in lowered_tags):
+            return True, clean[:360]
+    return True, first_nonempty[:360]
+
+
+def _source_exists_for(anchor: Anchor) -> bool:
+    return _source_file_info(anchor.source_path, anchor.tags)[0]
+
+
+def _source_excerpt_for(anchor: Anchor) -> str:
+    """Return a compact source excerpt from the backing file when present."""
+    return _source_file_info(anchor.source_path, anchor.tags)[1]
+
+
+def _row_value(row: sqlite3.Row, key: str) -> str:
+    try:
+        value = row[key]
+    except (IndexError, KeyError):
+        return ""
+    return "" if value is None else str(value)
+
+
+def _fallback_title(source: str, source_id: str) -> str:
+    label = (source or "ichor_source").replace("_", " ").strip()
+    label = label[:1].upper() + label[1:] if label else "Ichor source"
+    suffix = source_id.rsplit(":", 1)[-1] if source_id else ""
+    return f"{label} {suffix}".strip()
+
+
+def _clean_title(title: str, *, source: str, source_id: str) -> str:
+    raw = title or ""
+    raw_lower = raw.lower()
+    raw_fragment_markers = ("`", "|", "\n", "<", ">", "http", "www", "**", "#", "'", "=", ":", "/")
+    if any(marker in raw_lower for marker in raw_fragment_markers):
+        return _fallback_title(source, source_id)
+    full = " ".join(raw.split())
+    if not full:
+        return _fallback_title(source, source_id)
+    compact = full[:180]
+    if compact.endswith((",", ";")) or not compact[:1].isupper():
+        return _fallback_title(source, source_id)
+    if len(compact.split()) > 9 and not compact.endswith((".", ")")):
+        return _fallback_title(source, source_id)
+    return compact
+
+
+def _db_item(
+    *,
+    source: str,
+    source_id: str,
+    title: str,
+    text: str,
+    source_path: str,
+    source_excerpt: str = "",
+) -> dict[str, Any] | None:
+    clean = " ".join((text or "").split())
+    if not clean:
+        return None
+    return {
+        "title": _clean_title(title, source=source, source_id=source_id),
+        "text": clean[:420],
+        "snippet": clean[:320],
+        "source": source,
+        "source_path": source_path or source_id,
+        "source_id": source_id,
+        "source_excerpt": source_excerpt[:360] or clean[:320],
+        "path": source_path or source_id,
+        "id": source_id,
+    }
+
+
+def _append_unique(items: list[dict[str, Any]], candidate: dict[str, Any] | None) -> bool:
+    if candidate is None:
+        return False
+    candidate_key = (candidate.get("source"), candidate.get("source_id"))
+    candidate_text = str(candidate.get("text", "")).lower()[:160]
+    for item in items:
+        existing_key = (item.get("source"), item.get("source_id"))
+        existing_text = str(item.get("text", "")).lower()[:160]
+        if candidate_key == existing_key or candidate_text == existing_text:
+            return False
+    items.append(candidate)
+    return True
+
+
+def _item(anchor: Anchor) -> dict[str, Any]:
+    return {
+        "title": anchor.title,
+        "text": anchor.text,
+        "snippet": anchor.text[:320],
+        "source": "athenaeum",
+        "source_path": anchor.source_path,
+        "source_id": anchor.source_id,
+        "source_excerpt": _source_excerpt_for(anchor),
+        "path": anchor.source_path,
+        "id": anchor.source_id,
+    }
+
+
+def _score(anchor: Anchor, query_terms: set[str], god_name: str, phase: str, task_type: str) -> int:
+    tags = set(anchor.tags)
+    if not query_terms & tags:
+        return 0
+    score = anchor.priority
+    score += 18 * len(query_terms & tags)
+    if god_name.lower() in tags:
+        score += 80
+    if phase.lower() in tags:
+        score += 35
+    if task_type and task_type.lower() in tags:
+        score += 20
+    return score
+
+
+def _read_db_candidates(query: str, max_rows: int, deadline: float) -> tuple[list[dict[str, Any]], int, int, list[str]]:
+    if max_rows <= 0 or not ICHOR_DB.exists() or time.perf_counter() > deadline:
+        return [], 0, 0, []
+
+    cleaned = _sanitize_fts(query)
+    if not cleaned:
+        return [], 0, 0, ["unsafe_query"]
+
+    rows_examined = 0
+    db_reads = 0
+    omitted: list[str] = []
+    results: list[dict[str, Any]] = []
+    uri = f"file:{ICHOR_DB}?mode=ro"
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=0.05)
+        conn.row_factory = sqlite3.Row
+    except sqlite3.Error as exc:
+        return [], 0, 0, [f"db_unavailable:{exc.__class__.__name__}"]
+
+    try:
+        try:
+            claim_rows = conn.execute(
+                """
+                SELECT c.id, c.text, c.type, c.source_session_id,
+                       e.source_event_id, e.excerpt
+                FROM ichor_claims c
+                LEFT JOIN ichor_claim_evidence e ON e.claim_id = c.id
+                WHERE c.status = 'active' AND c.text LIKE ?
+                ORDER BY c.trust_score DESC, c.confidence DESC, c.id DESC
+                LIMIT ?
+                """,
+                (f"%{query}%", max_rows),
+            ).fetchall()
+            db_reads += 1
+            rows_examined += len(claim_rows)
+            for row in claim_rows:
+                if len(results) >= max_rows or time.perf_counter() > deadline:
+                    break
+                source_id = f"ichor_claims:{_row_value(row, 'id')}"
+                evidence_id = _row_value(row, "source_event_id")
+                source_path = _row_value(row, "source_session_id")
+                if evidence_id:
+                    source_path = source_path or f"ichor_events:{evidence_id}"
+                _append_unique(
+                    results,
+                    _db_item(
+                        source="ichor_claims",
+                        source_id=source_id,
+                        title=_row_value(row, "type") or source_id,
+                        text=_row_value(row, "text"),
+                        source_path=source_path,
+                        source_excerpt=_row_value(row, "excerpt"),
+                    ),
+                )
+        except sqlite3.Error as exc:
+            omitted.append(f"claims_query_failed:{exc.__class__.__name__}")
+
+        if len(results) < max_rows and time.perf_counter() <= deadline:
+            obs_rows = conn.execute(
+                """
+                SELECT o.id, o.subject, o.predicate, o.object, o.content,
+                       o.category, o.confidence, o.last_seen,
+                       s.source_session_id, s.source_god_name, s.event_id, s.quote
+                FROM ichor_observations_fts f
+                JOIN ichor_observations o ON f.rowid = o.id
+                LEFT JOIN (
+                    SELECT observation_id,
+                           MIN(source_session_id) AS source_session_id,
+                           MIN(source_god_name) AS source_god_name,
+                           MIN(event_id) AS event_id,
+                           MIN(quote) AS quote
+                    FROM ichor_observation_sources
+                    GROUP BY observation_id
+                ) s ON s.observation_id = o.id
+                WHERE ichor_observations_fts MATCH ?
+                GROUP BY o.id
+                LIMIT ?
+                """,
+                (cleaned, max_rows - len(results)),
+            ).fetchall()
+            db_reads += 1
+            rows_examined += len(obs_rows)
+            for row in obs_rows:
+                if len(results) >= max_rows or time.perf_counter() > deadline:
+                    break
+                source_id = f"ichor_observations:{_row_value(row, 'id')}"
+                event_id = _row_value(row, "event_id")
+                source_path = _row_value(row, "source_session_id")
+                if event_id:
+                    source_path = source_path or f"ichor_events:{event_id}"
+                title = _row_value(row, "subject") or _row_value(row, "category") or source_id
+                text = _row_value(row, "content") or " ".join(
+                    part for part in (
+                        _row_value(row, "subject"),
+                        _row_value(row, "predicate"),
+                        _row_value(row, "object"),
+                    ) if part
+                )
+                _append_unique(
+                    results,
+                    _db_item(
+                        source="ichor_observations",
+                        source_id=source_id,
+                        title=title,
+                        text=text,
+                        source_path=source_path,
+                        source_excerpt=_row_value(row, "quote"),
+                    ),
+                )
+
+        if len(results) < max_rows and time.perf_counter() <= deadline:
+            event_rows = conn.execute(
+                """
+                SELECT e.id, e.event_type, e.subject, e.raw_text,
+                       e.session_id, e.god_name, e.created_at
+                FROM ichor_events_fts f
+                JOIN ichor_events e ON f.rowid = e.id
+                WHERE ichor_events_fts MATCH ?
+                ORDER BY e.importance DESC, e.id DESC
+                LIMIT ?
+                """,
+                (cleaned, max_rows - len(results)),
+            ).fetchall()
+            db_reads += 1
+            rows_examined += len(event_rows)
+            for row in event_rows:
+                if len(results) >= max_rows or time.perf_counter() > deadline:
+                    break
+                raw_text = _row_value(row, "raw_text")
+                if not raw_text.strip():
+                    omitted.append("unhydrated_event")
+                    continue
+                source_id = f"ichor_events:{_row_value(row, 'id')}"
+                _append_unique(
+                    results,
+                    _db_item(
+                        source="ichor_events",
+                        source_id=source_id,
+                        title=_row_value(row, "subject") or _row_value(row, "event_type") or source_id,
+                        text=raw_text,
+                        source_path=_row_value(row, "session_id") or _row_value(row, "god_name") or source_id,
+                    ),
+                )
+    except sqlite3.Error as exc:
+        omitted.append(f"db_query_failed:{exc.__class__.__name__}")
+    finally:
+        conn.close()
+
+    if time.perf_counter() > deadline:
+        omitted.append("max_ms")
+    return results, db_reads, rows_examined, omitted
+
+
+def _collect_items(query: str, god_name: str, phase: str, task_type: str, max_items: int, max_ms: int) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if not _needs_memory_context(query, god_name, phase, task_type):
+        return [], {
+            "db_reads": 0,
+            "rows_examined": 0,
+            "omitted_reasons": ["classifier_no_memory_need"],
+        }
+
+    deadline = time.perf_counter() + max(max_ms, 1) / 1000.0
+    query_terms = _terms(query)
+    ranked: list[tuple[int, Anchor]] = []
+    omitted_reasons: list[str] = []
+
+    for anchor in ANCHORS:
+        if time.perf_counter() > deadline:
+            omitted_reasons.append("max_ms")
+            break
+        if not _source_exists_for(anchor):
+            omitted_reasons.append("missing_source")
+            continue
+        role_tags = ROLE_TAGS & set(anchor.tags)
+        if role_tags and god_name.lower() not in role_tags and phase.lower() not in anchor.tags:
+            omitted_reasons.append("role_mismatch")
+            continue
+        score = _score(anchor, query_terms, god_name, phase, task_type)
+        if score >= 90:
+            ranked.append((score, anchor))
+        else:
+            omitted_reasons.append("low_authority")
+
+    ranked.sort(key=lambda pair: (-pair[0], pair[1].source_id))
+    selected: list[dict[str, Any]] = []
+    for _, anchor in ranked[:max(max_items, 0)]:
+        _append_unique(selected, _item(anchor))
+    db_reads = 0
+    rows_examined = 0
+    if not selected and time.perf_counter() <= deadline:
+        # Phase 1 keeps live DB reads as a bounded fallback, not a mandatory
+        # addition to already-covered source anchors. This avoids making the
+        # golden-query path heavier than the default compressor baseline.
+        remaining_slots = max(max_items, 0) - len(selected)
+        db_items, db_reads, rows_examined, db_omitted = _read_db_candidates(
+            query, min(remaining_slots, 3), deadline
+        )
+        for item in db_items:
+            if len(selected) >= max_items:
+                break
+            _append_unique(selected, item)
+        omitted_reasons.extend(db_omitted)
+
+    return selected, {
+        "db_reads": db_reads,
+        "rows_examined": rows_examined + len(ranked),
+        "omitted_reasons": omitted_reasons,
+    }
+
+
+def _sectioned(items: Iterable[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    sections = {section: [] for section in PRIMARY_SECTIONS}
+    for item in items:
+        anchor = next((a for a in ANCHORS if a.source_id == item.get("source_id")), None)
+        section = anchor.section if anchor else "recent_changes"
+        sections.setdefault(section, []).append(item)
+    return sections
+
+
+def _source_links(items: Iterable[dict[str, Any]]) -> list[dict[str, str]]:
+    seen: set[tuple[str, str]] = set()
+    links: list[dict[str, str]] = []
+    for item in items:
+        key = (str(item.get("source_path", "")), str(item.get("source_id", "")))
+        if key in seen:
+            continue
+        seen.add(key)
+        links.append({
+            "title": str(item.get("title", "")),
+            "source_path": key[0],
+            "source_id": key[1],
+        })
+    return links
+
+
+def _render_context(pack: dict[str, Any]) -> str:
+    lines = [
+        f'<ichor-context source="ichor" mode="{pack["metrics"]["mode"]}" god="{pack["god"]}" phase="{pack["phase"]}">',
+        (
+            f'  <coverage status="{pack["coverage"]["status"]}" '
+            f'returned="{pack["coverage"]["returned"]}" omitted="{pack["coverage"]["omitted"]}" />'
+        ),
+    ]
+    for section in PRIMARY_SECTIONS:
+        items = pack.get(section) or []
+        if not items:
+            continue
+        xml_name = section.replace("_", "-")
+        lines.append(f"  <{xml_name}>")
+        for item in items:
+            lines.append(
+                f"    - {item['text']} Source: {item['source_path']}#{item['source_id']}"
+            )
+        lines.append(f"  </{xml_name}>")
+    lines.append("</ichor-context>")
+    return "\n".join(lines)
+
+
+def _trim_to_budget(pack: dict[str, Any], max_tokens: int) -> int:
+    removed = 0
+    while _estimate_tokens_text(_render_context(pack)) > max_tokens:
+        removed_this_round = False
+        for section in reversed(PRIMARY_SECTIONS):
+            items = pack.get(section) or []
+            if items:
+                items.pop()
+                removed += 1
+                removed_this_round = True
+                break
+        if not removed_this_round:
+            break
+    pack["injectable_context"] = _render_context(pack)
+    return removed
+
+
+def _primary_count(pack: dict[str, Any]) -> int:
+    return sum(len(pack[section]) for section in PRIMARY_SECTIONS)
+
+
+def build_context_pack(
+    query: str,
+    *,
+    god_name: str,
+    phase: str = "",
+    task_type: str = "",
+    max_items: int = 8,
+    max_tokens: int = 900,
+    max_ms: int = 350,
+    include_graph: bool = True,
+    dry_run: bool = False,
+) -> dict:
+    """Build a deterministic source-backed Ichor context pack."""
+    initial_omissions: list[str] = []
+    if include_graph:
+        initial_omissions.append("graph_not_attempted_phase1")
+    rss_before = _rss_kb()
+    started = time.perf_counter()
+    items, stats = _collect_items(query, god_name, phase, task_type, max_items, max_ms)
+    sections = _sectioned(items)
+    returned = sum(len(sections[section]) for section in PRIMARY_SECTIONS)
+    omitted_reasons = initial_omissions + stats["omitted_reasons"]
+    status = "ok" if returned else "low"
+    if time.perf_counter() - started > max(max_ms, 1) / 1000.0:
+        status = "low"
+        omitted_reasons.append("max_ms")
+
+    pack: dict[str, Any] = {
+        "query": query,
+        "god": god_name,
+        "phase": phase,
+        "injectable_context": "",
+        "coverage": {
+            "status": status,
+            "returned": returned,
+            "omitted": len(omitted_reasons),
+            "warnings": [] if returned else ["no_source_backed_context_found"],
+        },
+        "current_decisions": sections["current_decisions"],
+        "hard_constraints": sections["hard_constraints"],
+        "relevant_files": sections["relevant_files"],
+        "risks": sections["risks"],
+        "related_entities": sections["related_entities"],
+        "recent_changes": sections["recent_changes"],
+        "source_links": _source_links(items),
+        "omitted": {
+            "count": len(omitted_reasons),
+            "reasons": sorted(set(omitted_reasons)),
+        },
+        "metrics": {
+            "wall_ms": 0,
+            "db_reads": stats["db_reads"],
+            "db_writes": 0,
+            "rows_examined": stats["rows_examined"],
+            "tokens_estimated": 0,
+            "llm_calls": 0,
+            "api_calls": 0,
+            "rss_delta_kb": None,
+            "mode": "dry_run" if dry_run else "manual",
+        },
+    }
+    if returned:
+        removed_for_budget = _trim_to_budget(pack, max(max_tokens, 1))
+    else:
+        removed_for_budget = 0
+        pack["injectable_context"] = ""
+    if removed_for_budget:
+        pack["omitted"]["reasons"] = sorted(set(pack["omitted"]["reasons"] + ["token_budget"]))
+        pack["omitted"]["count"] += removed_for_budget
+    rss_after = _rss_kb()
+    pack["coverage"]["returned"] = _primary_count(pack)
+    pack["coverage"]["omitted"] = pack["omitted"]["count"]
+    pack["coverage"]["warnings"] = [] if pack["coverage"]["returned"] else ["no_source_backed_context_found"]
+    pack["metrics"]["tokens_estimated"] = _estimate_tokens_text(pack["injectable_context"])
+    pack["metrics"]["wall_ms"] = int((time.perf_counter() - started) * 1000)
+    pack["metrics"]["rss_delta_kb"] = (
+        None if rss_before is None or rss_after is None else rss_after - rss_before
+    )
+    return pack
+
+
+def ichor_context_pack(
+    query: str,
+    god_name: str = "",
+    phase: str = "",
+    task_type: str = "",
+    max_items: int = 8,
+    dry_run: bool = True,
+) -> str:
+    """Return the injectable context pack text for manual/tool callers."""
+    pack = build_context_pack(
+        query,
+        god_name=god_name,
+        phase=phase,
+        task_type=task_type,
+        max_items=max_items,
+        dry_run=dry_run,
+    )
+    return pack["injectable_context"]

--- a/lib/ichor/raw_turns.py
+++ b/lib/ichor/raw_turns.py
@@ -1,0 +1,231 @@
+"""Lossless raw-turn storage for the Ichor context engine.
+
+This module is intentionally small and deterministic. It owns only exact raw
+message persistence and a compact session frontier; derived extraction belongs
+to later Ichor enrichment lanes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_TABLES = ["ichor_raw_turns", "ichor_session_frontier"]
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS ichor_raw_turns (
+    session_id TEXT NOT NULL,
+    seq INTEGER NOT NULL,
+    role TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    content TEXT NOT NULL,
+    message_json TEXT NOT NULL,
+    tool_name TEXT,
+    tool_call_id TEXT,
+    source TEXT NOT NULL DEFAULT 'context_engine',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (session_id, seq)
+);
+CREATE INDEX IF NOT EXISTS idx_ichor_raw_turns_hash ON ichor_raw_turns(content_hash);
+CREATE INDEX IF NOT EXISTS idx_ichor_raw_turns_created ON ichor_raw_turns(created_at DESC);
+
+CREATE TABLE IF NOT EXISTS ichor_session_frontier (
+    session_id TEXT PRIMARY KEY,
+    last_ingested_seq INTEGER NOT NULL,
+    active_tail_start_seq INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+"""
+
+
+@dataclass(frozen=True)
+class RawTurn:
+    """One exact stored message from a Hermes session."""
+
+    session_id: str
+    seq: int
+    role: str
+    content: str
+    content_hash: str
+    message_json: str
+    tool_name: str | None = None
+    tool_call_id: str | None = None
+    source: str = "context_engine"
+    created_at: str | None = None
+
+
+class RawTurnStore:
+    """SQLite repository for exact raw turns and session frontiers."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.db_path = Path(db_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def migrate(self) -> dict[str, object]:
+        """Create raw-turn tables and indexes. Idempotent."""
+        with self._connect() as conn:
+            conn.executescript(SCHEMA_SQL)
+            conn.commit()
+            ready = [
+                table
+                for table in SCHEMA_TABLES
+                if conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+                    (table,),
+                ).fetchone()
+            ]
+        return {"tables_ready": ready}
+
+    def ingest_messages(
+        self,
+        session_id: str,
+        messages: list[dict[str, Any]],
+        *,
+        source: str = "context_engine",
+        active_tail_start_seq: int = 0,
+    ) -> dict[str, int]:
+        """Idempotently persist exact messages by ``(session_id, seq)``.
+
+        Existing rows are updated only when the content hash changes. Replaying
+        the same transcript therefore stays a no-op after the first insert.
+        """
+        self.migrate()
+        inserted = 0
+        updated = 0
+        last_seq = len(messages) - 1
+        with self._connect() as conn:
+            for seq, message in enumerate(messages):
+                normalized = self._normalize_message(message)
+                existing = conn.execute(
+                    "SELECT content_hash FROM ichor_raw_turns WHERE session_id=? AND seq=?",
+                    (session_id, seq),
+                ).fetchone()
+                params = (
+                    session_id,
+                    seq,
+                    normalized["role"],
+                    normalized["content_hash"],
+                    normalized["content"],
+                    normalized["message_json"],
+                    normalized["tool_name"],
+                    normalized["tool_call_id"],
+                    source,
+                )
+                if existing is None:
+                    conn.execute(
+                        """
+                        INSERT INTO ichor_raw_turns (
+                            session_id, seq, role, content_hash, content,
+                            message_json, tool_name, tool_call_id, source
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        params,
+                    )
+                    inserted += 1
+                elif existing["content_hash"] != normalized["content_hash"]:
+                    conn.execute(
+                        """
+                        UPDATE ichor_raw_turns
+                        SET role=?, content_hash=?, content=?, message_json=?,
+                            tool_name=?, tool_call_id=?, source=?, updated_at=datetime('now')
+                        WHERE session_id=? AND seq=?
+                        """,
+                        (
+                            normalized["role"],
+                            normalized["content_hash"],
+                            normalized["content"],
+                            normalized["message_json"],
+                            normalized["tool_name"],
+                            normalized["tool_call_id"],
+                            source,
+                            session_id,
+                            seq,
+                        ),
+                    )
+                    updated += 1
+            conn.execute(
+                """
+                INSERT INTO ichor_session_frontier (
+                    session_id, last_ingested_seq, active_tail_start_seq
+                ) VALUES (?, ?, ?)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    last_ingested_seq=excluded.last_ingested_seq,
+                    active_tail_start_seq=excluded.active_tail_start_seq,
+                    updated_at=datetime('now')
+                """,
+                (session_id, last_seq, max(0, int(active_tail_start_seq))),
+            )
+            conn.commit()
+        return {"seen": len(messages), "inserted": inserted, "updated": updated, "last_seq": last_seq}
+
+    def fetch_range(self, session_id: str, start_seq: int, end_seq: int) -> list[RawTurn]:
+        """Fetch exact raw turns for ``session_id`` in sequence order."""
+        self.migrate()
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT session_id, seq, role, content, content_hash, message_json,
+                       tool_name, tool_call_id, source, created_at
+                FROM ichor_raw_turns
+                WHERE session_id=? AND seq BETWEEN ? AND ?
+                ORDER BY seq ASC
+                """,
+                (session_id, int(start_seq), int(end_seq)),
+            ).fetchall()
+        return [RawTurn(**dict(row)) for row in rows]
+
+    def get_frontier(self, session_id: str) -> dict[str, Any] | None:
+        """Return compact frontier state without volatile timestamp fields."""
+        self.migrate()
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT session_id, last_ingested_seq, active_tail_start_seq
+                FROM ichor_session_frontier WHERE session_id=?
+                """,
+                (session_id,),
+            ).fetchone()
+        return dict(row) if row else None
+
+    @staticmethod
+    def _normalize_message(message: dict[str, Any]) -> dict[str, str | None]:
+        message_json = json.dumps(message, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        content = message.get("content", "")
+        if not isinstance(content, str):
+            content = json.dumps(content, ensure_ascii=False, sort_keys=True)
+        content_hash = hashlib.sha256(message_json.encode("utf-8")).hexdigest()
+        role = str(message.get("role") or "unknown")
+        tool_name = RawTurnStore._tool_name(message)
+        tool_call_id = message.get("tool_call_id")
+        return {
+            "role": role,
+            "content": content,
+            "content_hash": content_hash,
+            "message_json": message_json,
+            "tool_name": str(tool_name) if tool_name else None,
+            "tool_call_id": str(tool_call_id) if tool_call_id else None,
+        }
+
+    @staticmethod
+    def _tool_name(message: dict[str, Any]) -> str | None:
+        if message.get("name"):
+            return str(message["name"])
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, list) and tool_calls:
+            first = tool_calls[0]
+            if isinstance(first, dict):
+                function = first.get("function")
+                if isinstance(function, dict) and function.get("name"):
+                    return str(function["name"])
+        return None

--- a/scripts/benchmark-ichor-compressor-weight.py
+++ b/scripts/benchmark-ichor-compressor-weight.py
@@ -212,7 +212,7 @@ def _run_default_compressor(case: BenchmarkCase) -> dict[str, Any]:
     tokens_before = _estimate_messages_tokens(messages)
     call_counter = {"llm_calls": 0}
 
-    def bound_fake_summary(self: Any, turns: list[dict[str, Any]], focus_topic: str | None = None) -> str:
+    def bound_fake_summary(self: Any, turns: list[dict[str, Any]], focus_topic: str | None = None, **_kwargs: Any) -> str:
         return _fake_summary(case, call_counter, self, turns, focus_topic)
 
     compressor._generate_summary = MethodType(bound_fake_summary, compressor)  # type: ignore[attr-defined]

--- a/scripts/benchmark-ichor-compressor-weight.py
+++ b/scripts/benchmark-ichor-compressor-weight.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""Offline compressor-weight benchmark for Ichor context packs.
+
+This is the missing Phase 0/2 gate from the original handoff: exercise Hermes'
+default ``ContextCompressor`` on synthetic long transcripts that actually cross
+its threshold, then compare the Ichor context-pack candidate as a bounded memory
+augmentation. The default compressor path uses a deterministic fake summary so
+this benchmark never calls an LLM provider or mutates runtime state.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from types import MethodType
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HERMES_AGENT = ROOT / "hermes-agent"
+if str(HERMES_AGENT) not in sys.path:
+    sys.path.insert(0, str(HERMES_AGENT))
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+MAX_PACK_TOKENS = 900
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    """One benchmark row for compressor-vs-Ichor measurement."""
+
+    case_id: str
+    god: str
+    phase: str
+    query: str
+    expect_injection: bool
+    min_sources: int
+    max_pack_tokens: int = MAX_PACK_TOKENS
+
+
+CASES: tuple[BenchmarkCase, ...] = (
+    BenchmarkCase(
+        "hermes-lcm-risk-long-thread",
+        "hermes",
+        "ops",
+        "LCM risk recall and Ichor compressor replacement",
+        True,
+        2,
+    ),
+    BenchmarkCase(
+        "thoth-lcm-risk-long-thread",
+        "thoth",
+        "research",
+        "LCM risk recall and Ichor context-pack compressor augmentation",
+        True,
+        2,
+    ),
+    BenchmarkCase(
+        "hephaestus-conductor-long-debug-thread",
+        "hephaestus",
+        "debug",
+        "Conductor v2",
+        True,
+        3,
+    ),
+    BenchmarkCase(
+        "rheta-pricing-long-copy-thread",
+        "rheta",
+        "copywriting",
+        "Pantheon pricing managed retainer dedicated infrastructure",
+        True,
+        2,
+    ),
+    BenchmarkCase(
+        "casual-long-noop",
+        "hermes",
+        "chat",
+        "random casual hello",
+        False,
+        0,
+    ),
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _default_artifact_dir() -> Path:
+    return Path("/tmp") / f"ichor-compressor-weight-benchmark-{_utc_stamp()}"
+
+
+def _ensure_private_artifact_dir(artifact_dir: Path) -> None:
+    """Create artifact directory with owner-only permissions.
+
+    Case JSON artifacts include internal source paths/titles. Keep the benchmark
+    dry-run, but avoid making that metadata world-readable under shared /tmp.
+    """
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_dir.chmod(0o700)
+
+
+def _rss_kb() -> int | None:
+    try:
+        for line in Path("/proc/self/status").read_text(encoding="utf-8").splitlines():
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1])
+    except (OSError, IndexError, ValueError):
+        return None
+    return None
+
+
+def _estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
+    try:
+        from agent.model_metadata import estimate_messages_tokens_rough
+    except Exception:
+        return sum((len(str(message.get("content", ""))) + 3) // 4 for message in messages)
+    return int(estimate_messages_tokens_rough(messages))
+
+
+def _estimate_text_tokens(text: str) -> int:
+    return (len(text) + 3) // 4 if text else 0
+
+
+def _long_content(case: BenchmarkCase, turn: int, role: str) -> str:
+    topic = case.query
+    repeated = (
+        f"{topic} | Ichor memory expansion | compressor-weight benchmark | "
+        f"source grounding | no LCM re-enable | turn {turn} | role {role}. "
+    )
+    if case.expect_injection:
+        anchor = (
+            "The durable constraint is that Ichor should provide LCM-like recall "
+            "by selecting source-backed memory while the default compressor remains "
+            "the baseline until benchmark proof exists. "
+        )
+    else:
+        anchor = (
+            "Casual filler for a long transcript that should compress normally, "
+            "but should not trigger Ichor memory selection for the current query. "
+        )
+    return (anchor + repeated) * 18
+
+
+def _make_long_transcript(case: BenchmarkCase, threshold_tokens: int) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "system",
+            "content": (
+                "Synthetic long transcript for the Ichor compressor-weight benchmark. "
+                "It is offline fixture data and carries no live runtime state."
+            ),
+        }
+    ]
+    turn = 0
+    while True:
+        turn += 1
+        messages.append({"role": "user", "content": _long_content(case, turn, "user")})
+        messages.append({"role": "assistant", "content": _long_content(case, turn, "assistant")})
+        if turn >= 42 and _estimate_messages_tokens(messages) > threshold_tokens + 12_000:
+            return messages
+        if turn >= 90:
+            return messages
+
+
+def _fake_summary(case: BenchmarkCase, call_counter: dict[str, int], _self: Any, turns: list[dict[str, Any]], focus_topic: str | None = None) -> str:
+    call_counter["llm_calls"] += 1
+    first = str(turns[0].get("content", ""))[:180] if turns else ""
+    last = str(turns[-1].get("content", ""))[:180] if turns else ""
+    return "\n".join(
+        [
+            "## Historical Task Snapshot",
+            f"Synthetic benchmark summary for {case.case_id}.",
+            f"Focus topic: {focus_topic or case.query}.",
+            f"Compressed turns: {len(turns)}.",
+            "## Key Decisions",
+            "- Preserve source-backed Ichor memory context without re-enabling LCM.",
+            "- Keep default compressor as measured baseline until benchmark gates pass.",
+            "## Evidence Samples",
+            f"- First compressed sample: {first}",
+            f"- Last compressed sample: {last}",
+        ]
+    )
+
+
+def _run_default_compressor(case: BenchmarkCase) -> dict[str, Any]:
+    started = time.perf_counter()
+    rss_before = _rss_kb()
+    try:
+        from agent.context_compressor import ContextCompressor
+    except Exception as exc:
+        return {
+            "available": False,
+            "error": str(exc),
+            "api_calls": 0,
+            "llm_calls": 0,
+            "called_compress_method": False,
+        }
+
+    compressor = ContextCompressor(
+        model="compressor-weight-benchmark",
+        quiet_mode=True,
+        config_context_length=128_000,
+    )
+    messages = _make_long_transcript(case, compressor.threshold_tokens)
+    tokens_before = _estimate_messages_tokens(messages)
+    call_counter = {"llm_calls": 0}
+
+    def bound_fake_summary(self: Any, turns: list[dict[str, Any]], focus_topic: str | None = None) -> str:
+        return _fake_summary(case, call_counter, self, turns, focus_topic)
+
+    compressor._generate_summary = MethodType(bound_fake_summary, compressor)  # type: ignore[attr-defined]
+    would_compress = bool(compressor.should_compress(tokens_before))
+    has_window = bool(compressor.has_content_to_compress(messages))
+    compressed = compressor.compress(copy.deepcopy(messages), current_tokens=tokens_before, force=True)
+    tokens_after = _estimate_messages_tokens(compressed)
+    rss_after = _rss_kb()
+    return {
+        "available": True,
+        "engine": compressor.name,
+        "threshold_tokens": compressor.threshold_tokens,
+        "tail_token_budget": compressor.tail_token_budget,
+        "tokens_before": tokens_before,
+        "tokens_after": tokens_after,
+        "tokens_saved": tokens_before - tokens_after,
+        "message_count_before": len(messages),
+        "message_count_after": len(compressed),
+        "would_compress_by_threshold": would_compress,
+        "has_compressible_window": has_window,
+        "called_compress_method": True,
+        "compression_count": compressor.compression_count,
+        "summary_fallback_used": bool(getattr(compressor, "_last_summary_fallback_used", False)),
+        "summary_dropped_count": int(getattr(compressor, "_last_summary_dropped_count", 0) or 0),
+        "llm_calls": int(call_counter["llm_calls"]),
+        "api_calls": 0,
+        "wall_ms": int((time.perf_counter() - started) * 1000),
+        "rss_delta_kb": None if rss_before is None or rss_after is None else rss_after - rss_before,
+    }
+
+
+def _failed_ichor_pack(error: str, started: float) -> dict[str, Any]:
+    """Return a fail-closed candidate row when Ichor pack generation is unavailable."""
+    return {
+        "coverage_status": "error",
+        "returned": 0,
+        "omitted": 0,
+        "warnings": [error],
+        "injected": False,
+        "injectable_context_length": 0,
+        "source_link_count": 0,
+        "source_titles": [],
+        "source_paths": [],
+        "tokens_estimated": 0,
+        "db_reads": 0,
+        "db_writes": 0,
+        "rows_examined": 0,
+        "llm_calls": 0,
+        "api_calls": 0,
+        "wall_ms": int((time.perf_counter() - started) * 1000),
+        "rss_delta_kb": None,
+        "pack": {"error": error},
+    }
+
+
+def _run_ichor_context_pack(case: BenchmarkCase) -> dict[str, Any]:
+    started = time.perf_counter()
+    try:
+        from lib.ichor.context_pack import build_context_pack
+    except Exception as exc:
+        return _failed_ichor_pack(f"context_pack_import_failed: {exc}", started)
+
+    try:
+        pack = build_context_pack(
+            case.query,
+            god_name=case.god,
+            phase=case.phase,
+            max_items=8,
+            max_tokens=case.max_pack_tokens,
+            max_ms=350,
+            include_graph=True,
+            dry_run=True,
+        )
+    except Exception as exc:
+        return _failed_ichor_pack(f"context_pack_build_failed: {exc}", started)
+    coverage = pack.get("coverage", {})
+    metrics = pack.get("metrics", {})
+    source_links = pack.get("source_links", []) or []
+    injectable = str(pack.get("injectable_context", "") or "")
+    return {
+        "coverage_status": coverage.get("status"),
+        "returned": int(coverage.get("returned", 0) or 0),
+        "omitted": int(coverage.get("omitted", 0) or 0),
+        "warnings": list(coverage.get("warnings", []) or []) + list(pack.get("warnings", []) or []),
+        "injected": bool(injectable),
+        "injectable_context_length": len(injectable),
+        "source_link_count": len(source_links),
+        "source_titles": [str(link.get("title", "")) for link in source_links],
+        "source_paths": [str(link.get("source_path", "")) for link in source_links],
+        "tokens_estimated": int(metrics.get("tokens_estimated", 0) or 0),
+        "db_reads": int(metrics.get("db_reads", 0) or 0),
+        "db_writes": int(metrics.get("db_writes", 0) or 0),
+        "rows_examined": int(metrics.get("rows_examined", 0) or 0),
+        "llm_calls": int(metrics.get("llm_calls", 0) or 0),
+        "api_calls": int(metrics.get("api_calls", 0) or 0),
+        "wall_ms": int(metrics.get("wall_ms", int((time.perf_counter() - started) * 1000)) or 0),
+        "rss_delta_kb": metrics.get("rss_delta_kb"),
+        "pack": pack,
+    }
+
+
+def run_case(case: BenchmarkCase, artifact_dir: Path) -> tuple[dict[str, Any], Path]:
+    _ensure_private_artifact_dir(artifact_dir)
+    default = _run_default_compressor(case)
+    candidate = _run_ichor_context_pack(case)
+    no_mutation_flags = {
+        "would_mutate_runtime": False,
+        "would_rotate_session": False,
+        "would_rewrite_transcript": False,
+        "would_change_config": False,
+        "would_restart_gateway": False,
+    }
+
+    default_ok = (
+        bool(default.get("available"))
+        and bool(default.get("would_compress_by_threshold"))
+        and bool(default.get("has_compressible_window"))
+        and bool(default.get("called_compress_method"))
+        and int(default.get("api_calls", 0) or 0) == 0
+        and int(default.get("llm_calls", 0) or 0) == 1
+        and int(default.get("tokens_after", 0) or 0) < int(default.get("tokens_before", 0) or 0)
+        and int(default.get("message_count_after", 0) or 0) < int(default.get("message_count_before", 0) or 0)
+    )
+    if case.expect_injection:
+        candidate_quality_ok = (
+            candidate["injected"]
+            and candidate["source_link_count"] >= case.min_sources
+            and candidate["coverage_status"] == "ok"
+        )
+    else:
+        candidate_quality_ok = (
+            not candidate["injected"]
+            and candidate["source_link_count"] == 0
+            and candidate["db_reads"] == 0
+            and candidate["tokens_estimated"] == 0
+        )
+    candidate_safety_ok = (
+        candidate["llm_calls"] == 0
+        and candidate["api_calls"] == 0
+        and candidate["db_writes"] == 0
+        and candidate["tokens_estimated"] <= case.max_pack_tokens
+    )
+
+    tokens_after = int(default.get("tokens_after", 0) or 0)
+    pack_tokens = int(candidate["tokens_estimated"] or 0)
+    hybrid_tokens = tokens_after + pack_tokens
+    row = {
+        "case_id": case.case_id,
+        "god": case.god,
+        "phase": case.phase,
+        "query": case.query,
+        "expect_injection": case.expect_injection,
+        "min_sources": case.min_sources,
+        "max_pack_tokens": case.max_pack_tokens,
+        "default_compressor": default,
+        "ichor_context_pack": {k: v for k, v in candidate.items() if k != "pack"},
+        "hybrid_projection": {
+            "tokens_after_default_plus_pack": hybrid_tokens,
+            "pack_overhead_tokens": pack_tokens,
+            "pack_overhead_pct_of_default_after": round((pack_tokens / tokens_after * 100), 2) if tokens_after else None,
+            "would_rewrite_static_prefix": False,
+        },
+        "default_ok": default_ok,
+        "candidate_quality_ok": candidate_quality_ok,
+        "candidate_safety_ok": candidate_safety_ok,
+        "row_ready": default_ok and candidate_quality_ok and candidate_safety_ok,
+        **no_mutation_flags,
+    }
+    case_path = artifact_dir / f"{case.case_id}.json"
+    case_path.write_text(json.dumps({"row": row, "pack": candidate["pack"]}, indent=2, sort_keys=True), encoding="utf-8")
+    return row, case_path
+
+
+def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    positive_rows = [row for row in rows if row["expect_injection"]]
+    noop_rows = [row for row in rows if not row["expect_injection"]]
+    default_exercised = [
+        row for row in rows
+        if row["default_compressor"].get("called_compress_method")
+        and row["default_compressor"].get("has_compressible_window")
+        and row["default_compressor"].get("would_compress_by_threshold")
+    ]
+    all_default_rows_reduced_tokens = all(
+        int(row["default_compressor"].get("tokens_after", 0) or 0)
+        < int(row["default_compressor"].get("tokens_before", 0) or 0)
+        for row in rows
+    )
+    all_no_runtime_mutation = all(
+        not row["would_mutate_runtime"]
+        and not row["would_rotate_session"]
+        and not row["would_rewrite_transcript"]
+        and not row["would_change_config"]
+        and not row["would_restart_gateway"]
+        for row in rows
+    )
+    all_candidate_no_llm_api = all(
+        row["ichor_context_pack"]["llm_calls"] == 0
+        and row["ichor_context_pack"]["api_calls"] == 0
+        for row in rows
+    )
+    all_candidate_no_db_writes = all(row["ichor_context_pack"]["db_writes"] == 0 for row in rows)
+    all_pack_tokens_bounded = all(
+        row["ichor_context_pack"]["tokens_estimated"] <= row["max_pack_tokens"]
+        for row in rows
+    )
+    positive_rows_source_backed = all(
+        row["ichor_context_pack"]["source_link_count"] >= row["min_sources"]
+        and row["ichor_context_pack"]["injected"]
+        for row in positive_rows
+    )
+    noop_rows_clean = all(
+        not row["ichor_context_pack"]["injected"]
+        and row["ichor_context_pack"]["db_reads"] == 0
+        and row["ichor_context_pack"]["tokens_estimated"] == 0
+        for row in noop_rows
+    )
+    row_ready_all = all(row["row_ready"] for row in rows)
+    blockers: list[str] = []
+    if len(default_exercised) < len(positive_rows):
+        blockers.append("default_compressor_not_exercised_on_positive_rows")
+    if not all_default_rows_reduced_tokens:
+        blockers.append("default_compressor_did_not_reduce_tokens")
+    if not all_no_runtime_mutation:
+        blockers.append("runtime_mutation_flag_set")
+    if not all_candidate_no_llm_api:
+        blockers.append("candidate_used_llm_or_api")
+    if not all_candidate_no_db_writes:
+        blockers.append("candidate_wrote_db")
+    if not all_pack_tokens_bounded:
+        blockers.append("candidate_pack_exceeded_token_budget")
+    if not positive_rows_source_backed:
+        blockers.append("positive_rows_not_source_backed")
+    if not noop_rows_clean:
+        blockers.append("noop_rows_not_clean")
+    if not row_ready_all:
+        blockers.append("one_or_more_rows_not_ready")
+
+    return {
+        "rows_run": len(rows),
+        "positive_rows": len(positive_rows),
+        "noop_rows": len(noop_rows),
+        "default_compressor_exercised_rows": len(default_exercised),
+        "all_default_rows_reduced_tokens": all_default_rows_reduced_tokens,
+        "all_no_runtime_mutation": all_no_runtime_mutation,
+        "all_candidate_no_llm_api": all_candidate_no_llm_api,
+        "all_candidate_no_db_writes": all_candidate_no_db_writes,
+        "all_pack_tokens_bounded": all_pack_tokens_bounded,
+        "positive_rows_source_backed": positive_rows_source_backed,
+        "noop_rows_clean": noop_rows_clean,
+        "max_default_wall_ms": max((int(row["default_compressor"].get("wall_ms", 0) or 0) for row in rows), default=0),
+        "max_candidate_wall_ms": max((int(row["ichor_context_pack"].get("wall_ms", 0) or 0) for row in rows), default=0),
+        "max_candidate_tokens": max((int(row["ichor_context_pack"].get("tokens_estimated", 0) or 0) for row in rows), default=0),
+        "total_candidate_db_reads": sum(int(row["ichor_context_pack"].get("db_reads", 0) or 0) for row in rows),
+        "total_candidate_db_writes": sum(int(row["ichor_context_pack"].get("db_writes", 0) or 0) for row in rows),
+        "blockers": blockers,
+        "benchmark_ready": not blockers,
+    }
+
+
+def _format_report(payload: dict[str, Any]) -> str:
+    summary = payload["summary"]
+    lines = [
+        "# Ichor Compressor-Weight Benchmark",
+        "",
+        f"mode: {payload['mode']}",
+        f"benchmark_ready: {str(summary['benchmark_ready']).lower()}",
+        f"rows_run: {summary['rows_run']}",
+        f"default_compressor_exercised_rows: {summary['default_compressor_exercised_rows']}",
+        f"all_default_rows_reduced_tokens: {str(summary['all_default_rows_reduced_tokens']).lower()}",
+        f"all_candidate_no_llm_api: {str(summary['all_candidate_no_llm_api']).lower()}",
+        f"all_candidate_no_db_writes: {str(summary['all_candidate_no_db_writes']).lower()}",
+        f"noop_rows_clean: {str(summary['noop_rows_clean']).lower()}",
+        f"max_candidate_tokens: {summary['max_candidate_tokens']}",
+        "",
+        "## Rows",
+    ]
+    for row in payload["rows"]:
+        default = row["default_compressor"]
+        candidate = row["ichor_context_pack"]
+        lines.extend(
+            [
+                f"### {row['case_id']}",
+                f"row_ready: {str(row['row_ready']).lower()}",
+                (
+                    "default: "
+                    f"{default.get('tokens_before')} → {default.get('tokens_after')} tokens, "
+                    f"messages {default.get('message_count_before')} → {default.get('message_count_after')}, "
+                    f"llm_calls={default.get('llm_calls')} api_calls={default.get('api_calls')}"
+                ),
+                (
+                    "ichor: "
+                    f"injected={str(candidate.get('injected')).lower()} "
+                    f"sources={candidate.get('source_link_count')} "
+                    f"tokens={candidate.get('tokens_estimated')} "
+                    f"db_reads={candidate.get('db_reads')}"
+                ),
+                "",
+            ]
+        )
+    if summary["blockers"]:
+        lines.extend(["## Blockers", *[f"- {blocker}" for blocker in summary["blockers"]]])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def run_benchmark(artifact_dir: Path) -> dict[str, Any]:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+    case_paths: list[str] = []
+    for case in CASES:
+        row, case_path = run_case(case, artifact_dir)
+        rows.append(row)
+        case_paths.append(str(case_path))
+    summary = _summarize(rows)
+    payload = {
+        "mode": "compressor_weight_benchmark",
+        "artifact_dir": str(artifact_dir),
+        "would_mutate_runtime": False,
+        "would_rotate_session": False,
+        "would_rewrite_transcript": False,
+        "would_change_config": False,
+        "would_restart_gateway": False,
+        "summary": summary,
+        "rows": rows,
+        "case_paths": case_paths,
+    }
+    summary_path = artifact_dir / "summary.json"
+    report_path = artifact_dir / "BENCHMARK.md"
+    payload["summary_path"] = str(summary_path)
+    payload["report_path"] = str(report_path)
+    summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    report_path.write_text(_format_report(payload), encoding="utf-8")
+    return payload
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-dir", type=Path, default=None)
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    payload = run_benchmark(args.artifact_dir or _default_artifact_dir())
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_report(payload), end="")
+    return 0 if payload["summary"]["benchmark_ready"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark-ichor-context-engine-turns.py
+++ b/scripts/benchmark-ichor-context-engine-turns.py
@@ -35,6 +35,8 @@ class TurnCase:
     turns: int
     expect_pack: bool
     filler_topic: str
+    payload_repeat: int = 26
+    context_length: int = 128_000
 
 
 CASES = (
@@ -58,6 +60,15 @@ CASES = (
         turns=7,
         expect_pack=False,
         filler_topic="casual acknowledgement unrelated filler weather chatter low signal",
+    ),
+    TurnCase(
+        case_id="long-threshold-compressor-pressure",
+        query="Ichor context engine must preserve decisions after the default compressor threshold fires.",
+        turns=14,
+        expect_pack=True,
+        filler_topic="long transcript threshold pressure exact recall default compressor comparison",
+        payload_repeat=80,
+        context_length=64_000,
     ),
 )
 
@@ -96,7 +107,7 @@ def _long_payload(case: TurnCase, turn: int, role: str) -> str:
         )
     else:
         core += "No durable memory context should be selected for the current no-op acknowledgement. "
-    return core * 26
+    return core * case.payload_repeat
 
 
 def _assistant_payload(case: TurnCase, turn: int) -> str:
@@ -125,18 +136,18 @@ def _new_default_compressor(case: TurnCase) -> tuple[Any, dict[str, int]]:
     compressor = ContextCompressor(
         model="ichor-context-engine-turn-benchmark",
         quiet_mode=True,
-        config_context_length=128_000,
+        config_context_length=case.context_length,
     )
     counter = {"llm_calls": 0}
 
-    def bound_fake_summary(self: Any, turns: list[dict[str, Any]], focus_topic: str | None = None) -> str:
+    def bound_fake_summary(self: Any, turns: list[dict[str, Any]], focus_topic: str | None = None, **_kwargs: Any) -> str:
         return _fake_summary(case, counter, self, turns, focus_topic)
 
     compressor._generate_summary = MethodType(bound_fake_summary, compressor)  # type: ignore[attr-defined]
     return compressor, counter
 
 
-def _new_ichor_engine() -> Any:
+def _new_ichor_engine(case: TurnCase) -> Any:
     import importlib
 
     for loaded in list(sys.modules):
@@ -147,6 +158,10 @@ def _new_ichor_engine() -> Any:
     sys.path.insert(0, str(HERMES_AGENT))
     module = importlib.import_module("plugins.context_engine.ichor")
     engine = module.IchorContextEngine(fresh_tail_turns=6, max_pack_tokens=700, max_pack_ms=120)
+    engine.update_model(
+        model="ichor-context-engine-turn-benchmark",
+        context_length=case.context_length,
+    )
     engine.on_session_start("turn-benchmark")
     return engine
 
@@ -179,7 +194,7 @@ def _simulate_default(case: TurnCase) -> dict[str, Any]:
 
 
 def _simulate_ichor(case: TurnCase) -> dict[str, Any]:
-    engine = _new_ichor_engine()
+    engine = _new_ichor_engine(case)
     raw_messages: list[dict[str, str]] = [{"role": "system", "content": "Ichor context engine per-turn benchmark."}]
     per_turn: list[dict[str, Any]] = []
     injected_any = False
@@ -253,6 +268,7 @@ def run_case(case: TurnCase, artifact_dir: Path) -> dict[str, Any]:
         "would_change_config": False,
         "would_enable_lcm": False,
         "would_flip_fleet_default": False,
+        "default_compressor_exercised": default["compressions"] > 0,
     }
     (artifact_dir / f"{case.case_id}.json").write_text(json.dumps(row, indent=2, sort_keys=True), encoding="utf-8")
     return row
@@ -272,11 +288,16 @@ def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
     noop_rows = [row for row in rows if not row["expect_pack"]]
     if not all(row["ichor_context_engine"]["noop_clean"] for row in noop_rows):
         blockers.append("noop_not_clean")
+    threshold_rows = [row for row in rows if row["default_compressor"]["compressions"] > 0]
+    if not threshold_rows:
+        blockers.append("default_compressor_never_exercised")
     if not all(row["ichor_context_engine"]["all_turns_have_expand_handles"] for row in rows):
         blockers.append("missing_expand_handles")
     return {
         "rows_run": len(rows),
         "turns_run": turns,
+        "default_compressor_exercised_rows": len(threshold_rows),
+        "threshold_crossing_case_ids": [row["case_id"] for row in threshold_rows],
         "baseline_label": "full transcript resend baseline until compressor threshold",
         "token_estimate_method": "len_div_4_heuristic",
         "default_total_tokens": default_total,

--- a/scripts/benchmark-ichor-context-engine-turns.py
+++ b/scripts/benchmark-ichor-context-engine-turns.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Benchmark default-off IchorContextEngine on tokens sent per turn.
+
+This is the measurement gate for the course-correction marker: compare per-turn
+prompt economy, not just post-threshold compression size. It is offline,
+default-off, and does not mutate live Hermes profile/fleet configuration.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from types import MethodType
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+HERMES_AGENT = ROOT / "hermes-agent"
+for candidate in (str(HERMES_AGENT), str(ROOT)):
+    if candidate in sys.path:
+        sys.path.remove(candidate)
+for candidate in (str(ROOT), str(HERMES_AGENT)):
+    sys.path.insert(0, candidate)
+
+
+@dataclass(frozen=True)
+class TurnCase:
+    case_id: str
+    query: str
+    turns: int
+    expect_pack: bool
+    filler_topic: str
+
+
+CASES = (
+    TurnCase(
+        case_id="ichor-engine-build",
+        query="Build the default-off IchorContextEngine prototype and benchmark tokens per turn.",
+        turns=7,
+        expect_pack=True,
+        filler_topic="Ichor precision context engine benchmark source-backed recall frontier",
+    ),
+    TurnCase(
+        case_id="pr138-comparison",
+        query="Compare PR #138 with the Ichor context engine replacement path.",
+        turns=7,
+        expect_pack=True,
+        filler_topic="PR #138 compressor-weight benchmark context pack default compressor comparison",
+    ),
+    TurnCase(
+        case_id="casual-noop",
+        query="ok",
+        turns=7,
+        expect_pack=False,
+        filler_topic="casual acknowledgement unrelated filler weather chatter low signal",
+    ),
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _default_artifact_dir() -> Path:
+    return Path("/tmp") / f"ichor-context-engine-turn-benchmark-{_utc_stamp()}"
+
+
+def _ensure_private_artifact_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.chmod(0o700)
+
+
+def _estimate_text_tokens(text: str) -> int:
+    return max(1, (len(text) + 3) // 4) if text else 0
+
+
+def estimate_messages_tokens(messages: list[dict[str, Any]]) -> int:
+    return sum(_estimate_text_tokens(str(message.get("content", ""))) for message in messages)
+
+
+def _long_payload(case: TurnCase, turn: int, role: str) -> str:
+    core = (
+        f"{case.filler_topic} | turn={turn} | role={role} | "
+        "This is accumulated historical context that should remain exactly recallable "
+        "without being resent in full every turn. "
+    )
+    if case.expect_pack:
+        core += (
+            "Relevant durable constraints: Ichor is the lossless memory substrate; "
+            "IchorContextEngine is the bounded per-turn selector; compaction is fallback. "
+        )
+    else:
+        core += "No durable memory context should be selected for the current no-op acknowledgement. "
+    return core * 26
+
+
+def _assistant_payload(case: TurnCase, turn: int) -> str:
+    return (
+        f"Assistant response for {case.case_id} turn {turn}. "
+        "Keep exact raw-turn expansion possible while avoiding stale prompt cargo. "
+    ) * 18
+
+
+def _fake_summary(case: TurnCase, counter: dict[str, int], _self: Any, turns: list[dict[str, Any]], focus_topic: str | None = None) -> str:
+    counter["llm_calls"] += 1
+    return "\n".join([
+        "## Historical Task Snapshot",
+        f"Default-compressor fake summary for {case.case_id}.",
+        f"Focus topic: {focus_topic or case.query}.",
+        f"Compressed turns: {len(turns)}.",
+        "## Key Decisions",
+        "- Ichor should reduce tokens per turn by selecting only relevant source-backed context.",
+        "- Default compressor remains the measured baseline, not the destination.",
+    ])
+
+
+def _new_default_compressor(case: TurnCase) -> tuple[Any, dict[str, int]]:
+    from agent.context_compressor import ContextCompressor
+
+    compressor = ContextCompressor(
+        model="ichor-context-engine-turn-benchmark",
+        quiet_mode=True,
+        config_context_length=128_000,
+    )
+    counter = {"llm_calls": 0}
+
+    def bound_fake_summary(self: Any, turns: list[dict[str, Any]], focus_topic: str | None = None) -> str:
+        return _fake_summary(case, counter, self, turns, focus_topic)
+
+    compressor._generate_summary = MethodType(bound_fake_summary, compressor)  # type: ignore[attr-defined]
+    return compressor, counter
+
+
+def _new_ichor_engine() -> Any:
+    import importlib
+
+    for loaded in list(sys.modules):
+        if loaded == "plugins" or loaded.startswith("plugins.context_engine"):
+            del sys.modules[loaded]
+    if str(HERMES_AGENT) in sys.path:
+        sys.path.remove(str(HERMES_AGENT))
+    sys.path.insert(0, str(HERMES_AGENT))
+    module = importlib.import_module("plugins.context_engine.ichor")
+    engine = module.IchorContextEngine(fresh_tail_turns=6, max_pack_tokens=700, max_pack_ms=120)
+    engine.on_session_start("turn-benchmark")
+    return engine
+
+
+def _simulate_default(case: TurnCase) -> dict[str, Any]:
+    compressor, counter = _new_default_compressor(case)
+    active_messages: list[dict[str, str]] = [{"role": "system", "content": "Default compressor per-turn benchmark."}]
+    per_turn: list[dict[str, Any]] = []
+    for turn in range(1, case.turns + 1):
+        active_messages.append({"role": "user", "content": _long_payload(case, turn, "user") + "\nCurrent request: " + case.query})
+        before = estimate_messages_tokens(active_messages)
+        compressed_this_turn = False
+        if compressor.should_compress(before) and compressor.has_content_to_compress(active_messages):
+            active_messages = compressor.compress(copy.deepcopy(active_messages), current_tokens=before, focus_topic=case.query, force=True)
+            compressed_this_turn = True
+        sent = estimate_messages_tokens(active_messages)
+        per_turn.append({"turn": turn, "tokens_sent": sent, "compressed": compressed_this_turn})
+        active_messages.append({"role": "assistant", "content": _assistant_payload(case, turn)})
+    return {
+        "engine": "full_transcript_baseline_until_threshold",
+        "label": "full transcript resend baseline until compressor threshold",
+        "token_estimate_method": "len_div_4_heuristic",
+        "total_tokens": sum(row["tokens_sent"] for row in per_turn),
+        "avg_tokens_per_turn": round(sum(row["tokens_sent"] for row in per_turn) / len(per_turn), 2),
+        "compressions": sum(1 for row in per_turn if row["compressed"]),
+        "llm_calls": counter["llm_calls"],
+        "api_calls": 0,
+        "per_turn": per_turn,
+    }
+
+
+def _simulate_ichor(case: TurnCase) -> dict[str, Any]:
+    engine = _new_ichor_engine()
+    raw_messages: list[dict[str, str]] = [{"role": "system", "content": "Ichor context engine per-turn benchmark."}]
+    per_turn: list[dict[str, Any]] = []
+    injected_any = False
+    noop_clean = True
+    handles_all = True
+    handles_any = False
+    llm_calls = 0
+    api_calls = 0
+    for turn in range(1, case.turns + 1):
+        raw_messages.append({"role": "user", "content": _long_payload(case, turn, "user") + "\nCurrent request: " + case.query})
+        assembled = engine.compress(copy.deepcopy(raw_messages), current_tokens=estimate_messages_tokens(raw_messages), focus_topic=case.query)
+        sent = estimate_messages_tokens(assembled)
+        joined = "\n".join(str(message.get("content", "")) for message in assembled)
+        status = engine.get_status()
+        metrics = status["last_pack_metrics"]
+        llm_calls += int(metrics.get("llm_calls", 0) or 0)
+        api_calls += int(metrics.get("api_calls", 0) or 0)
+        injected = bool(status.get("last_injected"))
+        injected_any = injected_any or injected
+        if not case.expect_pack:
+            noop_clean = noop_clean and not injected and int(metrics.get("db_reads", 0) or 0) == 0
+        frontier_omitted = len([message for message in raw_messages if message.get("role") != "system"]) > engine.fresh_tail_turns
+        has_handle = "Available Ichor expansions" in joined
+        if frontier_omitted:
+            handles_all = handles_all and has_handle
+            handles_any = handles_any or has_handle
+        per_turn.append({
+            "turn": turn,
+            "tokens_sent": sent,
+            "injected": injected,
+            "db_reads": int(metrics.get("db_reads", 0) or 0),
+            "frontier_omitted": frontier_omitted,
+            "has_expand_handle": has_handle,
+        })
+        raw_messages.append({"role": "assistant", "content": _assistant_payload(case, turn)})
+    return {
+        "engine": "ichor_context_engine",
+        "token_estimate_method": "len_div_4_heuristic",
+        "total_tokens": sum(row["tokens_sent"] for row in per_turn),
+        "avg_tokens_per_turn": round(sum(row["tokens_sent"] for row in per_turn) / len(per_turn), 2),
+        "injected_any": injected_any,
+        "noop_clean": noop_clean,
+        "all_turns_have_expand_handles": handles_all and handles_any,
+        "llm_calls": llm_calls,
+        "api_calls": api_calls,
+        "per_turn": per_turn,
+    }
+
+
+def run_case(case: TurnCase, artifact_dir: Path) -> dict[str, Any]:
+    started = time.perf_counter()
+    default = _simulate_default(case)
+    ichor = _simulate_ichor(case)
+    row_ready = ichor["total_tokens"] < default["total_tokens"]
+    if case.expect_pack:
+        row_ready = row_ready and bool(ichor["injected_any"])
+    else:
+        row_ready = row_ready and bool(ichor["noop_clean"])
+    row = {
+        "case_id": case.case_id,
+        "query": case.query,
+        "turns": case.turns,
+        "expect_pack": case.expect_pack,
+        "default_compressor": default,
+        "ichor_context_engine": ichor,
+        "tokens_saved": default["total_tokens"] - ichor["total_tokens"],
+        "tokens_saved_ratio": round((default["total_tokens"] - ichor["total_tokens"]) / max(default["total_tokens"], 1), 4),
+        "row_ready": row_ready,
+        "wall_ms": int((time.perf_counter() - started) * 1000),
+        "would_mutate_runtime": False,
+        "would_change_config": False,
+        "would_enable_lcm": False,
+        "would_flip_fleet_default": False,
+    }
+    (artifact_dir / f"{case.case_id}.json").write_text(json.dumps(row, indent=2, sort_keys=True), encoding="utf-8")
+    return row
+
+
+def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    default_total = sum(row["default_compressor"]["total_tokens"] for row in rows)
+    ichor_total = sum(row["ichor_context_engine"]["total_tokens"] for row in rows)
+    turns = sum(int(row["turns"]) for row in rows)
+    blockers: list[str] = []
+    if ichor_total >= default_total:
+        blockers.append("ichor_not_lower_total_tokens")
+    if not all(row["row_ready"] for row in rows):
+        blockers.append("row_not_ready")
+    if not all(row["ichor_context_engine"]["llm_calls"] == 0 and row["ichor_context_engine"]["api_calls"] == 0 for row in rows):
+        blockers.append("ichor_hot_path_llm_or_api")
+    noop_rows = [row for row in rows if not row["expect_pack"]]
+    if not all(row["ichor_context_engine"]["noop_clean"] for row in noop_rows):
+        blockers.append("noop_not_clean")
+    if not all(row["ichor_context_engine"]["all_turns_have_expand_handles"] for row in rows):
+        blockers.append("missing_expand_handles")
+    return {
+        "rows_run": len(rows),
+        "turns_run": turns,
+        "baseline_label": "full transcript resend baseline until compressor threshold",
+        "token_estimate_method": "len_div_4_heuristic",
+        "default_total_tokens": default_total,
+        "ichor_total_tokens": ichor_total,
+        "tokens_saved": default_total - ichor_total,
+        "tokens_saved_ratio": round((default_total - ichor_total) / max(default_total, 1), 4),
+        "default_avg_tokens_per_turn": round(default_total / max(turns, 1), 2),
+        "ichor_avg_tokens_per_turn": round(ichor_total / max(turns, 1), 2),
+        "all_ichor_no_llm_api": all(row["ichor_context_engine"]["llm_calls"] == 0 and row["ichor_context_engine"]["api_calls"] == 0 for row in rows),
+        "all_noop_rows_clean": all(row["ichor_context_engine"]["noop_clean"] for row in noop_rows),
+        "all_rows_have_expand_handles": all(row["ichor_context_engine"]["all_turns_have_expand_handles"] for row in rows),
+        "all_no_runtime_mutation": all(not row["would_mutate_runtime"] and not row["would_change_config"] and not row["would_enable_lcm"] and not row["would_flip_fleet_default"] for row in rows),
+        "blockers": blockers,
+        "benchmark_ready": not blockers,
+    }
+
+
+def _write_report(path: Path, summary: dict[str, Any], rows: list[dict[str, Any]]) -> None:
+    lines = [
+        "# IchorContextEngine Tokens-Per-Turn Benchmark",
+        "",
+        f"- Benchmark ready: `{summary['benchmark_ready']}`",
+        f"- Baseline: `{summary['baseline_label']}`",
+        f"- Token estimate method: `{summary['token_estimate_method']}`",
+        f"- Default/baseline estimated tokens: `{summary['default_total_tokens']}`",
+        f"- Ichor estimated tokens: `{summary['ichor_total_tokens']}`",
+        f"- Tokens saved ratio: `{summary['tokens_saved_ratio']}`",
+        f"- Ichor avg tokens/turn: `{summary['ichor_avg_tokens_per_turn']}`",
+        "",
+        "| Case | Default total | Ichor total | Saved ratio | Ready |",
+        "| --- | ---: | ---: | ---: | --- |",
+    ]
+    for row in rows:
+        lines.append(
+            f"| {row['case_id']} | {row['default_compressor']['total_tokens']} | "
+            f"{row['ichor_context_engine']['total_tokens']} | {row['tokens_saved_ratio']} | {row['row_ready']} |"
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_benchmark(artifact_dir: Path | None = None) -> dict[str, Any]:
+    artifact_dir = artifact_dir or _default_artifact_dir()
+    _ensure_private_artifact_dir(artifact_dir)
+    rows = [run_case(case, artifact_dir) for case in CASES]
+    summary = _summarize(rows)
+    summary_path = artifact_dir / "summary.json"
+    report_path = artifact_dir / "BENCHMARK.md"
+    payload = {
+        "mode": "ichor_context_engine_turn_benchmark",
+        "artifact_dir": str(artifact_dir),
+        "summary": summary,
+        "rows": rows,
+        "summary_path": str(summary_path),
+        "report_path": str(report_path),
+    }
+    summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    _write_report(report_path, summary, rows)
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-dir", type=Path, default=None)
+    parser.add_argument("--format", choices=("json", "text"), default="text")
+    args = parser.parse_args(argv)
+    payload = run_benchmark(args.artifact_dir)
+    if args.format == "json":
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        summary = payload["summary"]
+        print(f"benchmark_ready={summary['benchmark_ready']} artifact_dir={payload['artifact_dir']}")
+    return 0 if payload["summary"]["benchmark_ready"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/doctor-ichor-canary.py
+++ b/scripts/doctor-ichor-canary.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Ichor disposable canary doctor.
+
+This command turns the Cash/ichor-canary lessons into a repeatable preflight
+report. Default mode is read-only and token-safe: it reports booleans, routing
+IDs, provider/model names, pool entry labels/statuses, and service state, but
+never prints API keys or Discord bot tokens.
+
+Optional ``--repair`` is deliberately narrow. It only rewrites benign A2A
+metadata in a profile whose name contains ``canary``; it never touches tokens,
+never restarts gateways, never changes fleet defaults, and never mutates
+production god profiles.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - yaml is present in normal Pantheon env
+    yaml = None
+
+
+DEFAULT_PROFILE_ROOT = Path.home() / ".hermes" / "profiles"
+SCRIPT_PATH = Path(__file__).resolve()
+PANTHEON_ROOT = SCRIPT_PATH.parents[1]
+PROFILE_BOOTSTRAP_APPLY = PANTHEON_ROOT / "conductor" / "scripts" / "profile-bootstrap-apply.py"
+EXPECTED_PROVIDER = "opencode-go"
+EXPECTED_MODEL = "deepseek-v4-flash"
+EXPECTED_BASE_URL = "https://opencode.ai/zen/go/v1"
+
+
+@dataclass
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+@dataclass
+class PoolSnapshot:
+    provider: str
+    selected_label: str | None
+    selected_status: str | None
+    entries: list[dict[str, Any]]
+    error: str | None = None
+
+
+def run_command(cmd: list[str], timeout: int = 20) -> CommandResult:
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return CommandResult(result.returncode, result.stdout, result.stderr)
+    except Exception as exc:
+        return CommandResult(1, "", f"{type(exc).__name__}: {exc}")
+
+
+def parse_env_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists() or path.is_symlink():
+        return values
+    for raw in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists() or yaml is None:
+        return {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8", errors="ignore"))
+    return data if isinstance(data, dict) else {}
+
+
+def env_has_key(env_values: dict[str, str], key: str) -> bool:
+    return bool(env_values.get(key))
+
+
+def channels_match(env_values: dict[str, str], config: dict[str, Any], channel: str) -> bool:
+    raw_discord_cfg = config.get("discord")
+    discord_cfg: dict[str, Any] = raw_discord_cfg if isinstance(raw_discord_cfg, dict) else {}
+    candidates = [
+        env_values.get("DISCORD_ALLOWED_CHANNELS", ""),
+        env_values.get("DISCORD_FREE_RESPONSE_CHANNELS", ""),
+        env_values.get("DISCORD_HOME_CHANNEL", ""),
+        str(discord_cfg.get("allowed_channels", "")),
+        str(discord_cfg.get("free_response_channels", "")),
+    ]
+    return bool(channel) and all(channel in c for c in candidates if c)
+
+
+def compression_config(config: dict[str, Any]) -> dict[str, str]:
+    raw_auxiliary = config.get("auxiliary")
+    auxiliary: dict[str, Any] = raw_auxiliary if isinstance(raw_auxiliary, dict) else {}
+    raw_compression = auxiliary.get("compression")
+    compression: dict[str, Any] = raw_compression if isinstance(raw_compression, dict) else {}
+    return {
+        "provider": str(compression.get("provider", "") or ""),
+        "model": str(compression.get("model", "") or ""),
+        "base_url": str(compression.get("base_url", "") or ""),
+    }
+
+
+def load_pool_snapshot(provider: str, profile_dir: Path) -> PoolSnapshot:
+    old_home = os.environ.get("HERMES_HOME")
+    os.environ["HERMES_HOME"] = str(profile_dir)
+    try:
+        hermes_path = "/usr/local/lib/hermes-agent"
+        if hermes_path not in sys.path:
+            sys.path.insert(0, hermes_path)
+        from agent.credential_pool import load_pool
+
+        pool = load_pool(provider)
+        selected = pool.select() if pool else None
+        entries: list[dict[str, Any]] = []
+        for idx, entry in enumerate(pool.entries() if pool else []):
+            entries.append({
+                "idx": idx,
+                "label": getattr(entry, "label", None),
+                "source": getattr(entry, "source", None),
+                "status": getattr(entry, "last_status", None),
+                "reason": getattr(entry, "last_error_reason", None),
+                "error_code": getattr(entry, "last_error_code", None),
+            })
+        return PoolSnapshot(
+            provider=provider,
+            selected_label=getattr(selected, "label", None) if selected else None,
+            selected_status=getattr(selected, "last_status", None) if selected else None,
+            entries=entries,
+        )
+    except Exception as exc:
+        return PoolSnapshot(provider=provider, selected_label=None, selected_status=None, entries=[], error=f"{type(exc).__name__}: {exc}")
+    finally:
+        if old_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = old_home
+
+
+def check_gateway(profile: str, runner: Callable[[list[str]], CommandResult]) -> dict[str, Any]:
+    unit = f"hermes-gateway@{profile}.service"
+    result = runner([
+        "systemctl", "--user", "show", unit,
+        "-p", "ActiveState", "-p", "SubState", "-p", "MainPID", "-p", "ExecMainStatus", "-p", "NRestarts",
+        "--value",
+    ])
+    values = result.stdout.split()
+    return {
+        "unit": unit,
+        "ok": result.returncode == 0 and len(values) >= 2 and values[0] == "active" and values[1] == "running",
+        "raw": " ".join(values[:5]),
+        "error": result.stderr.strip()[:240] if result.returncode != 0 else None,
+    }
+
+
+def check_a2a_listen(port: str, runner: Callable[[list[str]], CommandResult]) -> dict[str, Any]:
+    if not port:
+        return {"ok": False, "port": "", "listening": False}
+    result = runner(["ss", "-ltnp"])
+    listening = f":{port} " in result.stdout
+    return {"ok": result.returncode == 0 and listening, "port": port, "listening": listening}
+
+
+def check_canary_allowlist(profile: str) -> bool:
+    if not PROFILE_BOOTSTRAP_APPLY.exists():
+        return False
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        canonical = root / "canonical" / "devops" / "example-skill"
+        canonical.mkdir(parents=True)
+        (canonical / "SKILL.md").write_text("---\nname: example-skill\n---\n# Example\n", encoding="utf-8")
+        no_canon = root / "no-canon.txt"
+        no_canon.write_text("# empty\n", encoding="utf-8")
+        result = run_command([
+            sys.executable,
+            str(PROFILE_BOOTSTRAP_APPLY),
+            "--god", profile,
+            "--canonical-root", str(root / "canonical"),
+            "--profiles-root", str(root / "profiles"),
+            "--no-canon-report", str(no_canon),
+            "--json",
+        ])
+        return result.returncode == 0
+
+
+def smoke_compression(profile_dir: Path) -> dict[str, Any]:
+    old_home = os.environ.get("HERMES_HOME")
+    os.environ["HERMES_HOME"] = str(profile_dir)
+    try:
+        hermes_path = "/usr/local/lib/hermes-agent"
+        if hermes_path not in sys.path:
+            sys.path.insert(0, hermes_path)
+        from agent.auxiliary_client import call_llm
+
+        resp = call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": "Compress this to one word: successful successful successful"}],
+            max_tokens=16,
+            timeout=60,
+        )
+        content = (resp.choices[0].message.content or "").strip()
+        return {"ok": True, "content": content[:80]}
+    except Exception as exc:
+        return {"ok": False, "error_type": type(exc).__name__, "error": str(exc)[:240]}
+    finally:
+        if old_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = old_home
+
+
+def build_report(
+    *,
+    profile: str,
+    profile_dir: Path,
+    channel: str,
+    runner: Callable[[list[str]], CommandResult] = run_command,
+    pool_loader: Callable[[str], PoolSnapshot] | None = None,
+    allowlist_checker: Callable[[str], bool] = check_canary_allowlist,
+    compression_smoker: Callable[[], dict[str, Any]] | None = None,
+    token_exposed: bool = False,
+) -> dict[str, Any]:
+    env_path = profile_dir / ".env"
+    config_path = profile_dir / "config.yaml"
+    env_values = parse_env_file(env_path)
+    config = load_yaml(config_path)
+    compression = compression_config(config)
+    gateway = check_gateway(profile, runner)
+    a2a = check_a2a_listen(env_values.get("A2A_PORT", ""), runner)
+    pool_loader = pool_loader or (lambda provider: load_pool_snapshot(provider, profile_dir))
+    pool = pool_loader(compression["provider"] or EXPECTED_PROVIDER)
+    smoke = compression_smoker() if compression_smoker else {"ok": None, "content": None}
+
+    profile_exists = profile_dir.exists()
+    profile_isolated = env_path.exists() and not env_path.is_symlink()
+    discord_route_locked = channels_match(env_values, config, channel)
+    a2a_identity_ok = env_values.get("A2A_AGENT_NAME") == f"{profile} Pantheon"
+    compression_lane_ok = (
+        compression["provider"] == EXPECTED_PROVIDER
+        and compression["model"] == EXPECTED_MODEL
+        and compression["base_url"].rstrip("/") == EXPECTED_BASE_URL
+    )
+    selected_pool_ok = bool(pool.selected_label) and pool.selected_status in {None, "ok"}
+    canary_allowed = allowlist_checker(profile)
+    compression_ok = smoke.get("ok") in {True, None}
+
+    checks = {
+        "profile_exists": profile_exists,
+        "profile_isolated": profile_isolated,
+        "discord_token_present": env_has_key(env_values, "DISCORD_BOT_TOKEN"),
+        "discord_route_locked": discord_route_locked,
+        "a2a_identity_ok": a2a_identity_ok,
+        "a2a_listening": a2a["ok"],
+        "gateway_active": gateway["ok"],
+        "compression_lane_ok": compression_lane_ok,
+        "selected_pool_ok": selected_pool_ok,
+        "canary_allowed_by_scripts": canary_allowed,
+        "compression_smoke_ok": compression_ok,
+    }
+    ready = all(checks.values())
+
+    return {
+        "profile": profile,
+        "profile_path": str(profile_dir),
+        "ready": ready,
+        **checks,
+        "a2a_port": env_values.get("A2A_PORT", ""),
+        "gateway": gateway,
+        "compression_provider": compression["provider"],
+        "compression_model": compression["model"],
+        "compression_base_url": compression["base_url"],
+        "pool_provider": pool.provider,
+        "selected_pool_entry": pool.selected_label,
+        "selected_pool_status": pool.selected_status,
+        "pool_entries": pool.entries,
+        "pool_error": pool.error,
+        "canary_allowed_by_scripts": canary_allowed,
+        "compression_smoke": smoke.get("content") if smoke.get("ok") else None,
+        "compression_smoke_error": None if smoke.get("ok") else smoke,
+        "token_rotation_required": bool(token_exposed),
+        "repair_recommendations": repair_recommendations(profile, env_values, checks),
+    }
+
+
+def repair_recommendations(profile: str, env_values: dict[str, str], checks: dict[str, bool]) -> list[str]:
+    recs: list[str] = []
+    if not checks.get("a2a_identity_ok", False):
+        recs.append(f"set A2A_AGENT_NAME={profile} Pantheon")
+    if not checks.get("profile_isolated", False):
+        recs.append("replace symlinked/missing .env with isolated profile .env before testing")
+    if not checks.get("discord_route_locked", False):
+        recs.append("align DISCORD_ALLOWED_CHANNELS/FREE_RESPONSE/HOME with the canary channel")
+    return recs
+
+
+def repair_profile_metadata(*, profile: str, profile_dir: Path) -> dict[str, Any]:
+    if "canary" not in profile:
+        return {"applied": False, "reason": "repair_refused_non_canary_profile", "changes": {}}
+    env_path = profile_dir / ".env"
+    if not env_path.exists() or env_path.is_symlink():
+        return {"applied": False, "reason": "env_missing_or_symlinked", "changes": {}}
+    lines = env_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    target_name = f"{profile} Pantheon"
+    changes: dict[str, str] = {}
+    new_lines: list[str] = []
+    saw_name = False
+    for line in lines:
+        if line.startswith("A2A_AGENT_NAME="):
+            saw_name = True
+            if line != f"A2A_AGENT_NAME={target_name}":
+                line = f"A2A_AGENT_NAME={target_name}"
+                changes["A2A_AGENT_NAME"] = target_name
+        new_lines.append(line)
+    if not saw_name:
+        new_lines.append(f"A2A_AGENT_NAME={target_name}")
+        changes["A2A_AGENT_NAME"] = target_name
+    if changes:
+        env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    return {"applied": bool(changes), "reason": "ok", "changes": changes}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Token-safe doctor for the Ichor disposable canary profile.")
+    parser.add_argument("--profile", default="ichor-canary")
+    parser.add_argument("--channel", default="")
+    parser.add_argument("--profiles-root", type=Path, default=DEFAULT_PROFILE_ROOT)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--smoke-compression", action="store_true", help="make one real auxiliary compression LLM call")
+    parser.add_argument("--token-exposed", action="store_true", help="mark report with token_rotation_required=true")
+    parser.add_argument("--repair", action="store_true", help="repair only benign canary profile metadata; never restarts services")
+    args = parser.parse_args(argv)
+
+    profile_dir = args.profiles_root / args.profile
+    repair_result = None
+    if args.repair:
+        repair_result = repair_profile_metadata(profile=args.profile, profile_dir=profile_dir)
+
+    report = build_report(
+        profile=args.profile,
+        profile_dir=profile_dir,
+        channel=args.channel,
+        compression_smoker=(lambda: smoke_compression(profile_dir)) if args.smoke_compression else None,
+        token_exposed=args.token_exposed,
+    )
+    if repair_result is not None:
+        report["repair_result"] = repair_result
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"profile={report['profile']} ready={report['ready']} selected_pool={report['selected_pool_entry']}")
+        print(f"compression={report['compression_provider']}/{report['compression_model']} smoke={report['compression_smoke']}")
+        if report["repair_recommendations"]:
+            print("repair_recommendations:")
+            for rec in report["repair_recommendations"]:
+                print(f"- {rec}")
+    return 0 if report["ready"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dry-run-ichor-context-pack.py
+++ b/scripts/dry-run-ichor-context-pack.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Dry-run measurement scaffold for Ichor context packs.
+
+This command builds the candidate pack for reporting only. It measures a
+bounded synthetic transcript and, when requested, compares cheap default
+ContextCompressor feasibility metrics without calling the compression method.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HERMES_AGENT = ROOT / "hermes-agent"
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "ichor_golden_queries.yaml"
+
+if str(HERMES_AGENT) not in sys.path:
+    sys.path.insert(0, str(HERMES_AGENT))
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _rss_kb() -> int | None:
+    try:
+        for line in Path("/proc/self/status").read_text(encoding="utf-8").splitlines():
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1])
+    except (OSError, IndexError, ValueError):
+        pass
+
+    try:
+        import psutil
+    except ImportError:
+        return None
+    return int(psutil.Process().memory_info().rss // 1024)
+
+
+def _peak_rss_kb() -> int | None:
+    try:
+        import resource
+    except ImportError:
+        return None
+    peak = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return peak if peak >= 0 else None
+
+
+def _load_fixture_queries(warnings: list[str]) -> list[dict[str, Any]]:
+    try:
+        import yaml
+    except ImportError:
+        warnings.append("PyYAML unavailable; using synthetic query only")
+        return []
+
+    try:
+        with FIXTURE_PATH.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except FileNotFoundError:
+        warnings.append(f"golden query fixture missing: {FIXTURE_PATH}")
+        return []
+    except (OSError, yaml.YAMLError) as exc:
+        warnings.append(f"golden query fixture could not be loaded: {exc}")
+        return []
+
+    queries = data.get("queries") if isinstance(data, dict) else None
+    if not isinstance(queries, list):
+        warnings.append("golden query fixture has no queries list")
+        return []
+    return [item for item in queries if isinstance(item, dict)]
+
+
+def _synthetic_messages(args: argparse.Namespace, warnings: list[str]) -> tuple[list[dict[str, str]], int]:
+    queries = _load_fixture_queries(warnings)
+    selected = [
+        item for item in queries
+        if str(item.get("query", "")).lower() == args.query.lower()
+    ][: max(args.max_items, 0)]
+    if not selected:
+        selected = [{
+            "query": args.query,
+            "god": args.god,
+            "phase": args.phase,
+            "must_include": [],
+            "notes": "synthetic dry-run transcript row",
+        }]
+
+    messages: list[dict[str, str]] = [
+        {
+            "role": "system",
+            "content": "Synthetic Phase 0 dry-run transcript. No runtime state is attached.",
+        }
+    ]
+    for row in selected:
+        must_include = ", ".join(str(token) for token in row.get("must_include", []) or [])
+        notes = str(row.get("notes", "") or "")
+        messages.append({
+            "role": "user",
+            "content": (
+                f"[{row.get('god', args.god)}:{row.get('phase', args.phase)}] "
+                f"{row.get('query', args.query)}"
+            ),
+        })
+        messages.append({
+            "role": "assistant",
+            "content": f"Fixture expectations: {must_include}. Notes: {notes}",
+        })
+    return messages, len(selected)
+
+
+def _estimate_tokens(messages: list[dict[str, str]], warnings: list[str]) -> int:
+    try:
+        from agent.model_metadata import estimate_messages_tokens_rough
+    except Exception as exc:
+        warnings.append(f"default token estimator unavailable: {exc}")
+        return sum((len(message.get("content", "")) + 3) // 4 for message in messages)
+    return int(estimate_messages_tokens_rough(messages))
+
+
+def _default_compressor_baseline(messages: list[dict[str, str]], tokens: int, warnings: list[str]) -> dict[str, Any]:
+    try:
+        from agent.context_compressor import ContextCompressor
+    except Exception as exc:
+        warnings.append(f"default compressor unavailable: {exc}")
+        return {
+            "available": False,
+            "tokens_estimated": tokens,
+            "llm_calls": 0,
+        }
+
+    compressor = ContextCompressor(
+        model="phase0-dry-run",
+        quiet_mode=True,
+        config_context_length=128_000,
+    )
+    return {
+        "available": True,
+        "engine": compressor.name,
+        "model": compressor.model,
+        "context_length": compressor.context_length,
+        "threshold_tokens": compressor.threshold_tokens,
+        "tail_token_budget": compressor.tail_token_budget,
+        "tokens_estimated": tokens,
+        "has_compressible_window": bool(compressor.has_content_to_compress(messages)),
+        "would_compress_by_threshold": bool(compressor.should_compress(tokens)),
+        "would_call_compress_method": False,
+        "llm_calls": 0,
+        "api_calls": 0,
+    }
+
+
+def _build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    warnings: list[str] = []
+    rss_before = _rss_kb()
+    started = time.perf_counter()
+
+    messages, rows_examined = _synthetic_messages(args, warnings)
+    tokens = _estimate_tokens(messages, warnings)
+    try:
+        from lib.ichor.context_pack import build_context_pack
+        candidate_context_pack = build_context_pack(
+            args.query,
+            god_name=args.god,
+            phase=args.phase,
+            max_items=args.max_items,
+            dry_run=True,
+        )
+    except Exception as exc:
+        warnings.append(f"context pack builder unavailable: {exc}")
+        candidate_context_pack = {
+            "query": args.query,
+            "god": args.god,
+            "phase": args.phase,
+            "injectable_context": "",
+            "coverage": {
+                "status": "unknown",
+                "returned": 0,
+                "omitted": 0,
+                "warnings": ["context_pack_builder_unavailable"],
+            },
+            "current_decisions": [],
+            "hard_constraints": [],
+            "relevant_files": [],
+            "risks": [],
+            "related_entities": [],
+            "recent_changes": [],
+            "source_links": [],
+            "omitted": {"count": 0, "reasons": ["builder_unavailable"]},
+            "metrics": {
+                "wall_ms": 0,
+                "db_reads": 0,
+                "db_writes": 0,
+                "rows_examined": 0,
+                "tokens_estimated": 0,
+                "llm_calls": 0,
+                "api_calls": 0,
+                "rss_delta_kb": None,
+                "mode": "dry_run",
+            },
+        }
+
+    payload: dict[str, Any] = {
+        "mode": "dry_run",
+        "god": args.god,
+        "phase": args.phase,
+        "query": args.query,
+        "max_items": args.max_items,
+        "would_mutate_runtime": False,
+        "would_rotate_session": False,
+        "would_rewrite_transcript": False,
+        "would_change_config": False,
+        "would_restart_gateway": False,
+        "warnings": warnings,
+    }
+    payload["candidate_context_pack"] = candidate_context_pack
+    if args.compare_default_compressor:
+        payload["default_compressor_baseline"] = _default_compressor_baseline(
+            messages, tokens, warnings,
+        )
+
+    rss_after = _rss_kb()
+    peak_rss_kb = _peak_rss_kb() or rss_after
+    wall_ms = int((time.perf_counter() - started) * 1000)
+    rss_delta_kb = None if rss_before is None or rss_after is None else rss_after - rss_before
+    if rss_before is None or rss_after is None:
+        warnings.append("RSS metrics unavailable")
+
+    payload["metrics"] = {
+        "wall_ms": wall_ms,
+        "rss_delta_kb": rss_delta_kb,
+        "peak_rss_kb": peak_rss_kb,
+        "db_reads": candidate_context_pack["metrics"]["db_reads"],
+        "db_writes": 0,
+        "fixture_reads": 1 if FIXTURE_PATH.exists() else 0,
+        "rows_examined": rows_examined + candidate_context_pack["metrics"]["rows_examined"],
+        "tokens_estimated": tokens + candidate_context_pack["metrics"]["tokens_estimated"],
+        "llm_calls": 0,
+        "api_calls": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+    return payload
+
+
+def _format_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Ichor Context Pack Dry Run",
+        "",
+        f"mode: {payload['mode']}",
+        f"god: {payload['god']}",
+        f"phase: {payload['phase']}",
+        f"query: {payload['query']}",
+        f"would_mutate_runtime: {str(payload['would_mutate_runtime']).lower()}",
+        f"would_rotate_session: {str(payload['would_rotate_session']).lower()}",
+        f"would_rewrite_transcript: {str(payload['would_rewrite_transcript']).lower()}",
+        f"would_change_config: {str(payload['would_change_config']).lower()}",
+        f"would_restart_gateway: {str(payload['would_restart_gateway']).lower()}",
+        "",
+        "## Metrics",
+    ]
+    for key, value in payload["metrics"].items():
+        lines.append(f"{key}: {value}")
+    if "default_compressor_baseline" in payload:
+        lines.extend(["", "## Default Compressor Baseline"])
+        for key, value in payload["default_compressor_baseline"].items():
+            lines.append(f"{key}: {value}")
+    if "candidate_context_pack" in payload:
+        lines.extend(["", "## Candidate Context Pack"])
+        for key, value in payload["candidate_context_pack"].items():
+            lines.append(f"{key}: {value}")
+    if payload.get("warnings"):
+        lines.extend(["", "## Warnings"])
+        lines.extend(f"- {warning}" for warning in payload["warnings"])
+    return "\n".join(lines) + "\n"
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--god", required=True)
+    parser.add_argument("--phase", default="")
+    parser.add_argument("--query", required=True)
+    parser.add_argument("--max-items", type=int, default=8)
+    parser.add_argument("--compare-default-compressor", action="store_true")
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    payload = _build_payload(args)
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_markdown(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/replay-ichor-context-pack-canary.py
+++ b/scripts/replay-ichor-context-pack-canary.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Replay-only canary readiness harness for Ichor context packs.
+
+This command runs a bounded matrix through the dry-run context-pack builder,
+saves per-case JSON artifacts, and emits a readiness report. It is deliberately
+not a live rollout tool: it has no profile/config mutation, no service control,
+no session operations, no transcript rewrite, and no model compression call.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HERMES_AGENT = ROOT / "hermes-agent"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(HERMES_AGENT) not in sys.path:
+    sys.path.insert(0, str(HERMES_AGENT))
+
+
+@dataclass(frozen=True)
+class MatrixCase:
+    case_id: str
+    god: str
+    phase: str
+    query: str
+    category: str
+    min_returned: int = 1
+    expected_zero: bool = False
+
+
+MATRIX: tuple[MatrixCase, ...] = (
+    MatrixCase(
+        "hermes-operator-followup-status",
+        "hermes",
+        "ops",
+        "where did we leave the Ichor context pack?",
+        "operator_followup",
+        min_returned=2,
+    ),
+    MatrixCase(
+        "hermes-operator-followup-canary",
+        "hermes",
+        "ops",
+        "should we enable the Ichor context pack canary now?",
+        "operator_followup",
+        min_returned=1,
+    ),
+    MatrixCase("hephaestus-conductor-debug", "hephaestus", "debug", "Conductor v2", "golden", min_returned=3),
+    MatrixCase("thoth-conductor-research", "thoth", "research", "Conductor v2", "golden", min_returned=3),
+    MatrixCase(
+        "rheta-pricing-copywriting",
+        "rheta",
+        "copywriting",
+        "Pantheon pricing managed retainer dedicated infrastructure",
+        "golden",
+        min_returned=2,
+    ),
+    MatrixCase("hermes-lcm-ops", "hermes", "ops", "LCM", "risk_recall", min_returned=1),
+    MatrixCase("thoth-lcm-research", "thoth", "research", "LCM", "risk_recall", min_returned=1),
+    MatrixCase("hermes-noop-chat", "hermes", "chat", "random casual hello", "noop", expected_zero=True, min_returned=0),
+    MatrixCase("thoth-noop-chat", "thoth", "chat", "random casual hello", "noop", expected_zero=True, min_returned=0),
+    MatrixCase("hephaestus-noop-chat", "hephaestus", "chat", "random casual hello", "noop", expected_zero=True, min_returned=0),
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _default_artifact_dir() -> Path:
+    return Path("/tmp") / f"ichor-context-pack-canary-{_utc_stamp()}"
+
+
+def _estimate_baseline(query: str) -> dict[str, Any]:
+    messages = [
+        {"role": "system", "content": "Replay-only canary readiness harness."},
+        {"role": "user", "content": query},
+    ]
+    tokens = sum((len(message["content"]) + 3) // 4 for message in messages)
+    try:
+        from agent.model_metadata import estimate_messages_tokens_rough
+        tokens = int(estimate_messages_tokens_rough(messages))
+    except Exception:
+        pass
+
+    try:
+        from agent.context_compressor import ContextCompressor
+        compressor = ContextCompressor(
+            model="canary-replay-baseline",
+            quiet_mode=True,
+            config_context_length=128_000,
+        )
+        return {
+            "available": True,
+            "engine": compressor.name,
+            "tokens_estimated": tokens,
+            "source_link_count": 0,
+            "llm_calls": 0,
+            "api_calls": 0,
+            "would_call_model_method": False,
+            "would_compress_by_threshold": bool(compressor.should_compress(tokens)),
+            "has_compressible_window": bool(compressor.has_content_to_compress(messages)),
+        }
+    except Exception as exc:
+        return {
+            "available": False,
+            "error": str(exc),
+            "tokens_estimated": tokens,
+            "source_link_count": 0,
+            "llm_calls": 0,
+            "api_calls": 0,
+            "would_call_model_method": False,
+        }
+
+
+def _row_from_case(case: MatrixCase, artifact_dir: Path) -> tuple[dict[str, Any], Path]:
+    from lib.ichor.context_pack import build_context_pack
+
+    started = time.perf_counter()
+    pack = build_context_pack(
+        case.query,
+        god_name=case.god,
+        phase=case.phase,
+        max_items=8,
+        max_tokens=900,
+        max_ms=350,
+        include_graph=True,
+        dry_run=True,
+    )
+    wall_ms = int((time.perf_counter() - started) * 1000)
+    metrics = pack.get("metrics", {})
+    coverage = pack.get("coverage", {})
+    source_links = pack.get("source_links", []) or []
+    baseline = _estimate_baseline(case.query)
+    injectable = str(pack.get("injectable_context", "") or "")
+    returned = int(coverage.get("returned", 0) or 0)
+    db_reads = int(metrics.get("db_reads", 0) or 0)
+    tokens_estimated = int(metrics.get("tokens_estimated", 0) or 0)
+    source_link_count = len(source_links)
+
+    no_mutation_flags = {
+        "would_mutate_runtime": False,
+        "would_rotate_session": False,
+        "would_rewrite_transcript": False,
+        "would_change_config": False,
+        "would_restart_gateway": False,
+    }
+    zero_ok = (
+        returned == 0
+        and db_reads == 0
+        and tokens_estimated == 0
+        and len(injectable) == 0
+    )
+    source_ok = returned >= case.min_returned and source_link_count >= case.min_returned
+    if case.expected_zero:
+        quality_ok = zero_ok and coverage.get("status") == "low"
+    else:
+        quality_ok = source_ok and coverage.get("status") == "ok"
+
+    row = {
+        "case_id": case.case_id,
+        "god": case.god,
+        "phase": case.phase,
+        "query": case.query,
+        "category": case.category,
+        "expected_zero": case.expected_zero,
+        "min_returned": case.min_returned,
+        "coverage_status": coverage.get("status"),
+        "returned": returned,
+        "omitted": int(coverage.get("omitted", 0) or 0),
+        "warnings": list(coverage.get("warnings", []) or []) + list(pack.get("warnings", []) or []),
+        "source_link_count": source_link_count,
+        "source_titles": [str(link.get("title", "")) for link in source_links],
+        "source_paths": [str(link.get("source_path", "")) for link in source_links],
+        "injectable_context_length": len(injectable),
+        "tokens_estimated": tokens_estimated,
+        "wall_ms": int(metrics.get("wall_ms", wall_ms) or wall_ms),
+        "db_reads": db_reads,
+        "db_writes": int(metrics.get("db_writes", 0) or 0),
+        "llm_calls": int(metrics.get("llm_calls", 0) or 0),
+        "api_calls": int(metrics.get("api_calls", 0) or 0),
+        "rss_delta_kb": metrics.get("rss_delta_kb"),
+        "baseline": baseline,
+        "grounding_improved_vs_baseline": source_link_count > int(baseline.get("source_link_count", 0) or 0),
+        "row_safety_pass": (
+            int(metrics.get("llm_calls", 0) or 0) == 0
+            and int(metrics.get("api_calls", 0) or 0) == 0
+            and int(metrics.get("db_writes", 0) or 0) == 0
+        ),
+        "row_quality_pass": quality_ok,
+        **no_mutation_flags,
+    }
+    case_path = artifact_dir / f"{case.case_id}.json"
+    case_path.write_text(json.dumps({"row": row, "pack": pack}, indent=2, sort_keys=True), encoding="utf-8")
+    return row, case_path
+
+
+def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    positive_rows = [row for row in rows if not row["expected_zero"]]
+    noop_rows = [row for row in rows if row["expected_zero"]]
+    all_no_llm_api = all(row["llm_calls"] == 0 and row["api_calls"] == 0 for row in rows)
+    all_no_db_writes = all(row["db_writes"] == 0 for row in rows)
+    all_safety_flags_false = all(
+        not row["would_mutate_runtime"]
+        and not row["would_rotate_session"]
+        and not row["would_rewrite_transcript"]
+        and not row["would_change_config"]
+        and not row["would_restart_gateway"]
+        for row in rows
+    )
+    noop_rows_clean = all(row["row_quality_pass"] for row in noop_rows)
+    source_backed_rows_ok = all(row["row_quality_pass"] for row in positive_rows)
+    operator_followup_rows_ok = all(
+        row["row_quality_pass"]
+        for row in rows
+        if row["category"] == "operator_followup"
+    )
+    grounding_rows_improved = all(
+        row["grounding_improved_vs_baseline"] for row in positive_rows
+    )
+    safety_pass = all_no_llm_api and all_no_db_writes and all_safety_flags_false
+    quality_pass = noop_rows_clean and source_backed_rows_ok and operator_followup_rows_ok and grounding_rows_improved
+    blockers: list[str] = []
+    if not safety_pass:
+        blockers.append("safety_invariants_failed")
+    if not noop_rows_clean:
+        blockers.append("noop_rows_not_clean")
+    if not source_backed_rows_ok:
+        blockers.append("source_backed_rows_below_threshold")
+    if not grounding_rows_improved:
+        blockers.append("source_grounding_not_improved_vs_baseline")
+
+    return {
+        "rows_run": len(rows),
+        "positive_rows": len(positive_rows),
+        "noop_rows": len(noop_rows),
+        "safety_pass": safety_pass,
+        "quality_pass": quality_pass,
+        "canary_ready": safety_pass and quality_pass,
+        "all_no_llm_api": all_no_llm_api,
+        "all_no_db_writes": all_no_db_writes,
+        "all_safety_flags_false": all_safety_flags_false,
+        "noop_rows_clean": noop_rows_clean,
+        "source_backed_rows_ok": source_backed_rows_ok,
+        "operator_followup_rows_ok": operator_followup_rows_ok,
+        "grounding_rows_improved": grounding_rows_improved,
+        "max_wall_ms": max((int(row["wall_ms"] or 0) for row in rows), default=0),
+        "max_tokens_estimated": max((int(row["tokens_estimated"] or 0) for row in rows), default=0),
+        "total_db_reads": sum(int(row["db_reads"] or 0) for row in rows),
+        "total_db_writes": sum(int(row["db_writes"] or 0) for row in rows),
+        "blockers": blockers,
+    }
+
+
+def _format_report(payload: dict[str, Any]) -> str:
+    summary = payload["summary"]
+    lines = [
+        "# Ichor Context-Pack Canary Replay Report",
+        "",
+        f"Generated: {payload['generated_at']}",
+        f"Mode: {payload['mode']}",
+        f"Artifact dir: {payload['artifact_dir']}",
+        "",
+        "## Verdict",
+        f"- safety_pass: {str(summary['safety_pass']).lower()}",
+        f"- quality_pass: {str(summary['quality_pass']).lower()}",
+        f"- canary_ready: {str(summary['canary_ready']).lower()}",
+        f"- blockers: {', '.join(summary['blockers']) if summary['blockers'] else 'none'}",
+        "",
+        "## Safety boundary",
+        "- replay-only: true",
+        "- live profile mutation: false",
+        "- gateway restart: false",
+        "- session rotation: false",
+        "- transcript rewrite: false",
+        "- model/API calls: false",
+        "",
+        "## Matrix rows",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            f"- {row['case_id']}: {row['coverage_status']} returned={row['returned']} "
+            f"sources={row['source_link_count']} noop={str(row['expected_zero']).lower()} "
+            f"quality={str(row['row_quality_pass']).lower()}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def run_matrix(artifact_dir: Path) -> dict[str, Any]:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+    case_paths: list[str] = []
+    for case in MATRIX:
+        row, path = _row_from_case(case, artifact_dir)
+        rows.append(row)
+        case_paths.append(str(path))
+
+    payload = {
+        "mode": "dry_run_replay",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "artifact_dir": str(artifact_dir),
+        "would_mutate_runtime": False,
+        "would_rotate_session": False,
+        "would_rewrite_transcript": False,
+        "would_change_config": False,
+        "would_restart_gateway": False,
+        "rows": rows,
+        "summary": _summarize(rows),
+        "case_paths": case_paths,
+    }
+    summary_path = artifact_dir / "summary.json"
+    report_path = artifact_dir / "report.md"
+    payload["summary_path"] = str(summary_path)
+    payload["report_path"] = str(report_path)
+    summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    report_path.write_text(_format_report(payload), encoding="utf-8")
+    return payload
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-dir", type=Path, default=None)
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    payload = run_matrix(args.artifact_dir or _default_artifact_dir())
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_report(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/simulate-ichor-context-pack-rollout.py
+++ b/scripts/simulate-ichor-context-pack-rollout.py
@@ -12,13 +12,17 @@ Safety boundary:
 - no session rotation
 - no transcript rewrite
 - no runtime DB writes
+
+The simulation validates source titles for prompt hygiene. Source paths are
+recorded raw in artifacts for provenance/debugging and are intentionally not
+render-sanitized here; the builder remains responsible for generating safe
+injectable prompt text.
 """
 from __future__ import annotations
 
 import argparse
 import json
 import sys
-import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -137,7 +141,6 @@ def simulate_case(case: SimulationCase, artifact_dir: Path) -> tuple[dict[str, A
     from lib.ichor.context_pack import build_context_pack
 
     artifact_dir.mkdir(parents=True, exist_ok=True)
-    started = time.perf_counter()
     before_messages = _base_messages(case)
     before_tokens = _estimate_messages_tokens(before_messages)
     pack = build_context_pack(
@@ -160,7 +163,6 @@ def simulate_case(case: SimulationCase, artifact_dir: Path) -> tuple[dict[str, A
         after_messages.insert(1, _context_message(injectable))
     after_tokens = _estimate_messages_tokens(after_messages)
     source_link_count = len(source_links)
-    wall_ms = int((time.perf_counter() - started) * 1000)
     source_quality_ok = source_link_count >= case.min_sources and _source_titles_clean(source_links)
     noop_clean = (
         not case.expected_injection
@@ -196,7 +198,7 @@ def simulate_case(case: SimulationCase, artifact_dir: Path) -> tuple[dict[str, A
         "db_writes": int(metrics.get("db_writes", 0) or 0),
         "llm_calls": int(metrics.get("llm_calls", 0) or 0),
         "api_calls": int(metrics.get("api_calls", 0) or 0),
-        "wall_ms": int(metrics.get("wall_ms", wall_ms) or wall_ms),
+        "wall_ms": int(metrics.get("wall_ms", 0) or 0),
         "would_mutate_runtime": False,
         "would_change_config": False,
         "would_restart_gateway": False,

--- a/scripts/simulate-ichor-context-pack-rollout.py
+++ b/scripts/simulate-ichor-context-pack-rollout.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Controlled prompt-injection simulation for Ichor context packs.
+
+This is the gate after replay readiness and before any live/default-on wiring.
+It composes prompt-shaped messages with the candidate Ichor context pack inserted
+as an extra system message only when source-backed memory is actually returned.
+
+Safety boundary:
+- no model calls
+- no config writes
+- no gateway/service control
+- no session rotation
+- no transcript rewrite
+- no runtime DB writes
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+HERMES_AGENT = ROOT / "hermes-agent"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(HERMES_AGENT) not in sys.path:
+    sys.path.insert(0, str(HERMES_AGENT))
+
+
+@dataclass(frozen=True)
+class SimulationCase:
+    case_id: str
+    god: str
+    phase: str
+    query: str
+    expected_injection: bool
+    min_sources: int = 1
+    max_items: int = 8
+    max_tokens: int = 900
+    max_ms: int = 350
+
+
+MATRIX: tuple[SimulationCase, ...] = (
+    SimulationCase(
+        case_id="hermes-context-pack-followup",
+        god="hermes",
+        phase="ops",
+        query="where did we leave the Ichor context pack?",
+        expected_injection=True,
+        min_sources=2,
+    ),
+    SimulationCase(
+        case_id="hermes-canary-decision",
+        god="hermes",
+        phase="ops",
+        query="should we enable the Ichor context pack canary now?",
+        expected_injection=True,
+        min_sources=1,
+    ),
+    SimulationCase("hephaestus-conductor-debug", "hephaestus", "debug", "Conductor v2", True, min_sources=3),
+    SimulationCase("thoth-conductor-research", "thoth", "research", "Conductor v2", True, min_sources=3),
+    SimulationCase("rheta-pricing-copywriting", "rheta", "copywriting", "Pantheon pricing managed retainer dedicated infrastructure", True, min_sources=2),
+    SimulationCase("hermes-noop-chat", "hermes", "chat", "random casual hello", False, min_sources=0),
+    SimulationCase("thoth-noop-chat", "thoth", "chat", "random casual hello", False, min_sources=0),
+    SimulationCase("hephaestus-noop-chat", "hephaestus", "chat", "random casual hello", False, min_sources=0),
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _default_artifact_dir() -> Path:
+    return Path("/tmp") / f"ichor-context-pack-rollout-sim-{_utc_stamp()}"
+
+
+def _estimate_tokens_text(text: str) -> int:
+    try:
+        from agent.model_metadata import estimate_tokens_rough
+
+        return int(estimate_tokens_rough(text))
+    except Exception:
+        return max(0, (len(text) + 3) // 4)
+
+
+def _estimate_messages_tokens(messages: list[dict[str, str]]) -> int:
+    try:
+        from agent.model_metadata import estimate_messages_tokens_rough
+
+        return int(estimate_messages_tokens_rough(messages))
+    except Exception:
+        return sum(_estimate_tokens_text(message.get("content", "")) for message in messages)
+
+
+def _base_messages(case: SimulationCase) -> list[dict[str, str]]:
+    return [
+        {
+            "role": "system",
+            "content": (
+                f"You are {case.god}, a Pantheon operator. Phase: {case.phase}. "
+                "Use supplied source-backed context when present; ignore it when absent."
+            ),
+        },
+        {"role": "user", "content": case.query},
+    ]
+
+
+def _context_message(injectable_context: str) -> dict[str, str]:
+    return {
+        "role": "system",
+        "content": (
+            "The following block is a dry-run Ichor context pack candidate. "
+            "It is source-backed and bounded; do not treat it as a runtime mutation.\n\n"
+            f"{injectable_context}"
+        ),
+    }
+
+
+def _source_titles_clean(source_links: list[dict[str, Any]]) -> bool:
+    forbidden = ("```", "\n", "http://", "https://", "www.", "|")
+    for link in source_links:
+        title = str(link.get("title", ""))
+        if not title.strip():
+            return False
+        lowered = title.lower()
+        if any(token in lowered for token in forbidden):
+            return False
+    return True
+
+
+def simulate_case(case: SimulationCase, artifact_dir: Path) -> tuple[dict[str, Any], Path]:
+    from lib.ichor.context_pack import build_context_pack
+
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    started = time.perf_counter()
+    before_messages = _base_messages(case)
+    before_tokens = _estimate_messages_tokens(before_messages)
+    pack = build_context_pack(
+        case.query,
+        god_name=case.god,
+        phase=case.phase,
+        max_items=case.max_items,
+        max_tokens=case.max_tokens,
+        max_ms=case.max_ms,
+        include_graph=True,
+        dry_run=True,
+    )
+    injectable = str(pack.get("injectable_context", "") or "")
+    coverage = pack.get("coverage", {})
+    metrics = pack.get("metrics", {})
+    source_links = list(pack.get("source_links") or [])
+    injected = bool(injectable and int(coverage.get("returned", 0) or 0) > 0)
+    after_messages = list(before_messages)
+    if injected:
+        after_messages.insert(1, _context_message(injectable))
+    after_tokens = _estimate_messages_tokens(after_messages)
+    source_link_count = len(source_links)
+    wall_ms = int((time.perf_counter() - started) * 1000)
+    source_quality_ok = source_link_count >= case.min_sources and _source_titles_clean(source_links)
+    noop_clean = (
+        not case.expected_injection
+        and not injected
+        and source_link_count == 0
+        and int(metrics.get("db_reads", 0) or 0) == 0
+        and int(metrics.get("tokens_estimated", 0) or 0) == 0
+        and not injectable
+    )
+    injection_quality_ok = injected and source_quality_ok and after_tokens > before_tokens
+    row_quality_pass = injection_quality_ok if case.expected_injection else noop_clean
+    row = {
+        "case_id": case.case_id,
+        "god": case.god,
+        "phase": case.phase,
+        "query": case.query,
+        "expected_injection": case.expected_injection,
+        "injected": injected,
+        "coverage_status": coverage.get("status"),
+        "returned": int(coverage.get("returned", 0) or 0),
+        "source_link_count": source_link_count,
+        "source_titles": [str(link.get("title", "")) for link in source_links],
+        "source_paths": [str(link.get("source_path", "")) for link in source_links],
+        "source_titles_clean": _source_titles_clean(source_links),
+        "prompt_message_count_before": len(before_messages),
+        "prompt_message_count_after": len(after_messages),
+        "prompt_tokens_before": before_tokens,
+        "prompt_tokens_after": after_tokens,
+        "prompt_token_delta": after_tokens - before_tokens,
+        "injectable_context_length": len(injectable),
+        "tokens_estimated": int(metrics.get("tokens_estimated", 0) or 0),
+        "db_reads": int(metrics.get("db_reads", 0) or 0),
+        "db_writes": int(metrics.get("db_writes", 0) or 0),
+        "llm_calls": int(metrics.get("llm_calls", 0) or 0),
+        "api_calls": int(metrics.get("api_calls", 0) or 0),
+        "wall_ms": int(metrics.get("wall_ms", wall_ms) or wall_ms),
+        "would_mutate_runtime": False,
+        "would_change_config": False,
+        "would_restart_gateway": False,
+        "would_rotate_session": False,
+        "would_rewrite_transcript": False,
+        "row_safety_pass": (
+            int(metrics.get("db_writes", 0) or 0) == 0
+            and int(metrics.get("llm_calls", 0) or 0) == 0
+            and int(metrics.get("api_calls", 0) or 0) == 0
+        ),
+        "row_quality_pass": row_quality_pass,
+    }
+    case_path = artifact_dir / f"{case.case_id}.json"
+    case_path.write_text(
+        json.dumps({"row": row, "pack": pack, "messages_before": before_messages, "messages_after": after_messages}, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return row, case_path
+
+
+def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    noop_rows = [row for row in rows if not row["expected_injection"]]
+    injection_rows = [row for row in rows if row["expected_injection"]]
+    all_no_llm_api = all(row["llm_calls"] == 0 and row["api_calls"] == 0 for row in rows)
+    all_no_db_writes = all(row["db_writes"] == 0 for row in rows)
+    all_safety_flags_false = all(
+        not row["would_mutate_runtime"]
+        and not row["would_change_config"]
+        and not row["would_restart_gateway"]
+        and not row["would_rotate_session"]
+        and not row["would_rewrite_transcript"]
+        for row in rows
+    )
+    injection_rows_ok = all(row["row_quality_pass"] for row in injection_rows)
+    noop_rows_clean = all(row["row_quality_pass"] for row in noop_rows)
+    safety_pass = all_no_llm_api and all_no_db_writes and all_safety_flags_false
+    quality_pass = injection_rows_ok and noop_rows_clean
+    blockers: list[str] = []
+    if not safety_pass:
+        blockers.append("safety_invariants_failed")
+    if not injection_rows_ok:
+        blockers.append("injection_rows_failed_quality")
+    if not noop_rows_clean:
+        blockers.append("noop_rows_not_clean")
+    return {
+        "rows_run": len(rows),
+        "injection_rows": len(injection_rows),
+        "noop_rows": len(noop_rows),
+        "safety_pass": safety_pass,
+        "quality_pass": quality_pass,
+        "rollout_sim_ready": safety_pass and quality_pass,
+        "all_no_llm_api": all_no_llm_api,
+        "all_no_db_writes": all_no_db_writes,
+        "all_safety_flags_false": all_safety_flags_false,
+        "injection_rows_ok": injection_rows_ok,
+        "noop_rows_clean": noop_rows_clean,
+        "max_prompt_token_delta": max((row["prompt_token_delta"] for row in rows), default=0),
+        "max_prompt_tokens_after": max((row["prompt_tokens_after"] for row in rows), default=0),
+        "total_db_reads": sum(row["db_reads"] for row in rows),
+        "total_db_writes": sum(row["db_writes"] for row in rows),
+        "blockers": blockers,
+    }
+
+
+def format_report(payload: dict[str, Any]) -> str:
+    summary = payload["summary"]
+    lines = [
+        "# Ichor Context-Pack Prompt Injection Simulation",
+        "",
+        f"Generated: {payload['generated_at']}",
+        f"Mode: {payload['mode']}",
+        f"Artifact dir: {payload['artifact_dir']}",
+        "",
+        "## Verdict",
+        f"- safety_pass: {str(summary['safety_pass']).lower()}",
+        f"- quality_pass: {str(summary['quality_pass']).lower()}",
+        f"- rollout_sim_ready: {str(summary['rollout_sim_ready']).lower()}",
+        f"- blockers: {', '.join(summary['blockers']) if summary['blockers'] else 'none'}",
+        "",
+        "## Safety boundary",
+        "- prompt simulation only: true",
+        "- live profile mutation: false",
+        "- gateway restart: false",
+        "- session rotation: false",
+        "- transcript rewrite: false",
+        "- model/API calls: false",
+        "",
+        "## Rows",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            f"- {row['case_id']}: injected={str(row['injected']).lower()} "
+            f"sources={row['source_link_count']} prompt_delta={row['prompt_token_delta']} "
+            f"quality={str(row['row_quality_pass']).lower()}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def run_simulation(artifact_dir: Path) -> dict[str, Any]:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+    case_paths: list[str] = []
+    for case in MATRIX:
+        row, path = simulate_case(case, artifact_dir)
+        rows.append(row)
+        case_paths.append(str(path))
+    payload = {
+        "mode": "prompt_injection_simulation",
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "artifact_dir": str(artifact_dir),
+        "would_mutate_runtime": False,
+        "would_change_config": False,
+        "would_restart_gateway": False,
+        "would_rotate_session": False,
+        "would_rewrite_transcript": False,
+        "rows": rows,
+        "summary": summarize(rows),
+        "case_paths": case_paths,
+    }
+    summary_path = artifact_dir / "summary.json"
+    report_path = artifact_dir / "report.md"
+    payload["summary_path"] = str(summary_path)
+    payload["report_path"] = str(report_path)
+    summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    report_path.write_text(format_report(payload), encoding="utf-8")
+    return payload
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-dir", type=Path, default=None)
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    payload = run_simulation(args.artifact_dir or _default_artifact_dir())
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(format_report(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/ichor_golden_queries.yaml
+++ b/tests/fixtures/ichor_golden_queries.yaml
@@ -1,0 +1,95 @@
+# Ichor Golden Queries — god-aware retrieval acceptance set
+#
+# Spec: ~/pantheon/plans/ichor-athenaeum-god-aware-retrieval-build-spec-v1.md §Phase 0
+#
+# Each query is paired with the (god, phase) it is being asked from, plus
+# must_include tokens that the answer MUST contain (substring match against
+# the result's title/snippet/raw_text) and must_not_top3 tokens that the
+# top-3 ranked results MUST NOT contain (e.g. generic index docs, raw test
+# fixtures, unhydrated vector stubs).
+#
+# The first two rows are deliberately the same query text for two different
+# gods. They prove the system differentiates role-specific context.
+#
+# Test files that consume this fixture:
+#   tests/test_ichor_context_pack.py
+#   tests/test_ichor_retrieval_observability.py
+#   (indirectly: tests/test_ichor_graph_*)
+
+version: 1
+spec: ichor-athenaeum-god-aware-retrieval-build-spec-v1.md §Phase 0
+
+queries:
+
+  # ─────────────────────────────────────────────────────────────────────
+  # 1. Same query, Hephaestus (engineer / debug phase)
+  #    Hephaestus builds + deploys + debugs. He needs the runtime seam:
+  #    NATS transport, MCP tool surface, the endpoint shape, and the
+  #    systemd service that hosts it.
+  # ─────────────────────────────────────────────────────────────────────
+  - id: hephaestus_conductor_v2_debug
+    query: "Conductor v2"
+    god: hephaestus
+    phase: debug
+    task_type: ""
+    must_include:
+      - "NATS"
+      - "MCP"
+      - "endpoint"
+      - "systemd"
+    must_not_top3:
+      - "INDEX.md"
+      - "unhydrated vector"
+    notes: >
+      Hephaestus needs the build/deploy/debug seam. The system must rank
+      Conductor v2 spec, the ichor_graph_query MCP endpoint, the NATS
+      transport, and the hermes-gateway systemd unit. Generic INDEX.md
+      is not a debug answer.
+
+  # ─────────────────────────────────────────────────────────────────────
+  # 2. Same query, Thoth (research / synthesis phase)
+  #    Thoth studies systems and writes synthesis docs. The same
+  #    Conductor v2 query must surface the *design* layer: workflow
+  #    definition, cross-god routing, and orchestration concepts —
+  #    not the runtime seam.
+  # ─────────────────────────────────────────────────────────────────────
+  - id: thoth_conductor_v2_research
+    query: "Conductor v2"
+    god: thoth
+    phase: research
+    task_type: ""
+    must_include:
+      - "workflow"
+      - "cross-god"
+      - "routing"
+    must_not_top3:
+      - "raw test fixture"
+      - "unhydrated vector"
+    notes: >
+      Thoth does the design synthesis. The same query must surface the
+      Conductor v2 design: workflow shape, cross-god handoff, and
+      routing decisions. Raw test fixtures and unhydrated vector stubs
+      are noise for a research query.
+
+  # ─────────────────────────────────────────────────────────────────────
+  # 3. Rheta (copywriting / pricing vertical)
+  #    Rheta is the marketing god. Pricing copy lives in plans/ and
+  #    pricing-distilled codexes. The query text mimics natural
+  #    marketing-research phrasing.
+  # ─────────────────────────────────────────────────────────────────────
+  - id: rheta_pantheon_pricing_retainer
+    query: "Pantheon pricing managed retainer dedicated infrastructure"
+    god: rheta
+    phase: copywriting
+    task_type: ""
+    must_include:
+      - "$5k"
+      - "managed"
+      - "dedicated infrastructure"
+    must_not_top3:
+      - "no subscriptions"
+      - "self-hosted"
+    notes: >
+      Rheta writes pricing copy. The answer must surface the $5k tier,
+      the "managed" offering, and the "dedicated infrastructure" lane.
+      "no subscriptions" and "self-hosted" would defeat the positioning.

--- a/tests/test_doctor_ichor_canary.py
+++ b/tests/test_doctor_ichor_canary.py
@@ -1,0 +1,127 @@
+"""Contract tests for the disposable Ichor canary doctor.
+
+The Cash/ichor-canary incident crossed four surfaces at once: profile env
+isolation, Discord routing, A2A clone drift, and OpenCode Go credential-pool
+selection. The doctor script exists so the next canary can be checked with one
+bounded, token-safe report instead of an ad-hoc debug sequence.
+
+These tests pin three non-negotiable boundaries:
+
+* report generation never includes secret values;
+* default/read-only doctor runs do not mutate profile files; and
+* repair mode is explicitly canary-scoped before it may rewrite benign A2A env
+  metadata.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "doctor-ichor-canary.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("doctor_ichor_canary", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_profile(root: Path, profile: str = "ichor-canary", *, a2a_name: str = "ichor-canary Pantheon") -> Path:
+    profile_dir = root / profile
+    profile_dir.mkdir(parents=True)
+    (profile_dir / ".env").write_text(
+        "DISCORD_BOT_TOKEN=super-secret-token-value\n"
+        "DISCORD_ALLOWED_CHANNELS=1530994028206755871\n"
+        "DISCORD_FREE_RESPONSE_CHANNELS=1530994028206755871\n"
+        "DISCORD_HOME_CHANNEL=1530994028206755871\n"
+        "A2A_AGENT_NAME=" + a2a_name + "\n"
+        "A2A_PORT=9913\n"
+        "OPENCODE_GO_API_KEY=super-secret-opencode-key\n",
+        encoding="utf-8",
+    )
+    (profile_dir / "config.yaml").write_text(
+        "auxiliary:\n"
+        "  compression:\n"
+        "    provider: opencode-go\n"
+        "    model: deepseek-v4-flash\n"
+        "    base_url: https://opencode.ai/zen/go/v1\n"
+        "discord:\n"
+        "  allowed_channels: '1530994028206755871'\n"
+        "  free_response_channels: '1530994028206755871'\n",
+        encoding="utf-8",
+    )
+    return profile_dir
+
+
+def test_report_is_token_safe_and_ready_when_all_checks_pass(tmp_path):
+    module = load_module()
+    profile_dir = write_profile(tmp_path)
+
+    def fake_runner(cmd):
+        if cmd[:1] == ["ss"]:
+            return module.CommandResult(0, "LISTEN 0 5 127.0.0.1:9913 0.0.0.0:* users:((\"hermes\",pid=123,fd=18))\n", "")
+        return module.CommandResult(0, "active running 123 0 0\n", "")
+
+    report = module.build_report(
+        profile="ichor-canary",
+        profile_dir=profile_dir,
+        channel="1530994028206755871",
+        runner=fake_runner,
+        pool_loader=lambda provider: module.PoolSnapshot(
+            provider=provider,
+            selected_label="opencode-go-nextcloud-3",
+            selected_status="ok",
+            entries=[
+                {"idx": 0, "label": "opencode-go-nextcloud-1", "status": "exhausted", "reason": "region_error"},
+                {"idx": 1, "label": "opencode-go-nextcloud-2", "status": "exhausted", "reason": "GoUsageLimitError"},
+                {"idx": 2, "label": "opencode-go-nextcloud-3", "status": "ok", "reason": None},
+            ],
+        ),
+        allowlist_checker=lambda profile: True,
+        compression_smoker=lambda: {"ok": True, "content": "successful"},
+        token_exposed=True,
+    )
+
+    payload = json.dumps(report, sort_keys=True)
+    assert report["ready"] is True
+    assert report["profile_isolated"] is True
+    assert report["discord_route_locked"] is True
+    assert report["compression_provider"] == "opencode-go"
+    assert report["compression_model"] == "deepseek-v4-flash"
+    assert report["selected_pool_entry"] == "opencode-go-nextcloud-3"
+    assert report["compression_smoke"] == "successful"
+    assert report["canary_allowed_by_scripts"] is True
+    assert report["token_rotation_required"] is True
+    assert "super-secret" not in payload
+
+
+def test_repair_refuses_non_canary_profile(tmp_path):
+    module = load_module()
+    profile_dir = write_profile(tmp_path, profile="thoth", a2a_name="thoth Pantheon")
+
+    result = module.repair_profile_metadata(profile="thoth", profile_dir=profile_dir)
+
+    assert result["applied"] is False
+    assert result["reason"] == "repair_refused_non_canary_profile"
+    assert "thoth Pantheon" in (profile_dir / ".env").read_text(encoding="utf-8")
+
+
+def test_repair_updates_only_canary_a2a_metadata_and_preserves_secret_lines(tmp_path):
+    module = load_module()
+    profile_dir = write_profile(tmp_path, a2a_name="thoth Pantheon")
+
+    result = module.repair_profile_metadata(profile="ichor-canary", profile_dir=profile_dir)
+
+    env_text = (profile_dir / ".env").read_text(encoding="utf-8")
+    assert result["applied"] is True
+    assert result["changes"] == {"A2A_AGENT_NAME": "ichor-canary Pantheon"}
+    assert "A2A_AGENT_NAME=ichor-canary Pantheon" in env_text
+    assert "DISCORD_BOT_TOKEN=super-secret-token-value" in env_text
+    assert "OPENCODE_GO_API_KEY=super-secret-opencode-key" in env_text

--- a/tests/test_ichor_compressor_weight_benchmark.py
+++ b/tests/test_ichor_compressor_weight_benchmark.py
@@ -1,0 +1,165 @@
+"""Tests for the real compressor-weight benchmark gate.
+
+These assert the handoff's missing measurement: default ContextCompressor must be
+exercised on long transcripts, not merely threshold-probed on tiny replay rows.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "benchmark-ichor-compressor-weight.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("benchmark_ichor_compressor_weight", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_benchmark_case_exercises_default_compressor_without_api_calls(tmp_path: Path) -> None:
+    module = load_module()
+
+    row, artifact = module.run_case(
+        module.BenchmarkCase(
+            case_id="hermes-lcm-risk-long-thread",
+            god="hermes",
+            phase="ops",
+            query="LCM risk recall and Ichor compressor replacement",
+            expect_injection=True,
+            min_sources=2,
+        ),
+        tmp_path,
+    )
+
+    assert artifact.exists()
+    baseline = row["default_compressor"]
+    assert baseline["available"] is True
+    assert baseline["would_compress_by_threshold"] is True
+    assert baseline["has_compressible_window"] is True
+    assert baseline["called_compress_method"] is True
+    assert baseline["api_calls"] == 0
+    assert baseline["llm_calls"] == 1
+    assert baseline["tokens_after"] < baseline["tokens_before"]
+    assert baseline["message_count_after"] < baseline["message_count_before"]
+
+    candidate = row["ichor_context_pack"]
+    assert candidate["injected"] is True
+    assert candidate["source_link_count"] >= 2
+    assert candidate["llm_calls"] == 0
+    assert candidate["api_calls"] == 0
+    assert candidate["db_writes"] == 0
+    assert candidate["tokens_estimated"] <= row["max_pack_tokens"]
+
+    assert row["would_mutate_runtime"] is False
+    assert row["would_rotate_session"] is False
+    assert row["would_rewrite_transcript"] is False
+    assert row["would_change_config"] is False
+    assert row["would_restart_gateway"] is False
+    assert row["row_ready"] is True
+
+
+def test_noop_case_stays_zero_read_zero_injection(tmp_path: Path) -> None:
+    module = load_module()
+
+    row, artifact = module.run_case(
+        module.BenchmarkCase(
+            case_id="casual-long-noop",
+            god="hermes",
+            phase="chat",
+            query="random casual hello",
+            expect_injection=False,
+            min_sources=0,
+        ),
+        tmp_path,
+    )
+
+    assert artifact.exists()
+    candidate = row["ichor_context_pack"]
+    assert candidate["injected"] is False
+    assert candidate["source_link_count"] == 0
+    assert candidate["db_reads"] == 0
+    assert candidate["tokens_estimated"] == 0
+    assert row["row_ready"] is True
+
+
+def test_cli_writes_benchmark_artifacts_and_summary(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "benchmark"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--format",
+            "json",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = json.loads(proc.stdout)
+    summary = payload["summary"]
+
+    assert payload["mode"] == "compressor_weight_benchmark"
+    assert payload["would_mutate_runtime"] is False
+    assert summary["rows_run"] >= 4
+    assert summary["benchmark_ready"] is True
+    assert summary["default_compressor_exercised_rows"] >= 3
+    assert summary["all_default_rows_reduced_tokens"] is True
+    assert summary["all_no_runtime_mutation"] is True
+    assert summary["all_candidate_no_llm_api"] is True
+    assert summary["all_candidate_no_db_writes"] is True
+    assert summary["noop_rows_clean"] is True
+    assert summary["blockers"] == []
+    assert Path(payload["summary_path"]).exists()
+    assert Path(payload["report_path"]).exists()
+    assert len(payload["case_paths"]) == summary["rows_run"]
+    assert artifact_dir.stat().st_mode & 0o777 == 0o700
+
+
+def test_ichor_pack_import_failure_is_reported_as_failing_row(tmp_path: Path) -> None:
+    module = load_module()
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "lib.ichor.context_pack":
+            raise ImportError("synthetic context-pack import miss")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        row, artifact = module.run_case(
+            module.BenchmarkCase(
+                case_id="hermes-lcm-risk-long-thread",
+                god="hermes",
+                phase="ops",
+                query="LCM risk recall and Ichor compressor replacement",
+                expect_injection=True,
+                min_sources=2,
+            ),
+            tmp_path,
+        )
+
+    assert artifact.exists()
+    candidate = row["ichor_context_pack"]
+    assert candidate["coverage_status"] == "error"
+    assert candidate["injected"] is False
+    assert candidate["llm_calls"] == 0
+    assert candidate["api_calls"] == 0
+    assert candidate["db_writes"] == 0
+    assert any("context_pack_import_failed" in warning for warning in candidate["warnings"])
+    assert row["candidate_quality_ok"] is False
+    assert row["candidate_safety_ok"] is True
+    assert row["row_ready"] is False

--- a/tests/test_ichor_context_engine.py
+++ b/tests/test_ichor_context_engine.py
@@ -1,0 +1,263 @@
+"""RED tests for the default-off IchorContextEngine prototype.
+
+The target is not another sidecar context-pack gate. These tests define the
+minimum compressor-replacement surface from docs/specs/ichor-precision-context-engine.md:
+lossless turn ingestion, bounded per-turn assembly, exact recall handles, no-op
+cleanliness, and no LLM/API calls on the hot path.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HERMES_AGENT = ROOT / "hermes-agent"
+for candidate in (str(ROOT), str(HERMES_AGENT)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+# Pantheon also has a top-level `plugins` package. These tests target Hermes'
+# context-engine plugin loader, so evict any already-imported sibling package
+# and force the hermes-agent path to win.
+for loaded in list(sys.modules):
+    if loaded == "plugins" or loaded.startswith("plugins.context_engine"):
+        del sys.modules[loaded]
+if str(HERMES_AGENT) in sys.path:
+    sys.path.remove(str(HERMES_AGENT))
+sys.path.insert(0, str(HERMES_AGENT))
+
+
+def _long_messages(current_user: str) -> list[dict[str, str]]:
+    messages: list[dict[str, str]] = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "Original project goal: reduce context tokens."},
+        {"role": "assistant", "content": "Acknowledged."},
+    ]
+    for idx in range(24):
+        messages.append({
+            "role": "user",
+            "content": (
+                f"Stale middle user turn {idx}: old canary mechanics, gateway routing, "
+                "token rotation, and verbose logs that should not be pasted each turn. " * 8
+            ),
+        })
+        messages.append({
+            "role": "assistant",
+            "content": (
+                f"Stale middle assistant turn {idx}: implementation detail dump. "
+                "This text exists to make the transcript large and should become recallable, "
+                "not live prompt cargo. " * 8
+            ),
+        })
+    messages.extend([
+        {"role": "user", "content": "Fresh tail: PR #138 benchmark is ready."},
+        {"role": "assistant", "content": "Fresh tail: benchmark is source-backed and default-off."},
+        {"role": "user", "content": current_user},
+    ])
+    return messages
+
+
+def _estimate_tokens(messages: list[dict[str, str]]) -> int:
+    return sum(max(1, (len(str(m.get("content", ""))) + 3) // 4) for m in messages)
+
+
+def test_ichor_context_engine_plugin_loads_default_off() -> None:
+    from plugins.context_engine import discover_context_engines, load_context_engine
+
+    discovered = {name for name, _description, available in discover_context_engines() if available}
+    assert "ichor" in discovered
+
+    engine = load_context_engine("ichor")
+    assert engine is not None
+    assert engine.name == "ichor"
+    assert engine.get_status()["mode"] == "default_off_plugin"
+
+
+def test_ichor_context_engine_assembles_bounded_relevant_context(monkeypatch) -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    engine = module.IchorContextEngine(fresh_tail_turns=4, max_pack_tokens=220)
+    engine.on_session_start("session-1", platform="discord")
+
+    def fake_pack(**kwargs):
+        assert kwargs["query"] == "Build the default-off IchorContextEngine prototype."
+        return {
+            "injectable_context": "<ichor-context>source-backed engine target</ichor-context>",
+            "source_links": [
+                {"title": "precision context design", "source_path": "docs/specs/ichor-precision-context-engine.md", "source_id": "target"}
+            ],
+            "metrics": {"llm_calls": 0, "api_calls": 0, "db_reads": 1, "db_writes": 0, "tokens_estimated": 13},
+            "coverage": {"returned": 1, "warnings": []},
+        }
+
+    monkeypatch.setattr(engine, "_build_context_pack", fake_pack)
+    original = _long_messages("Build the default-off IchorContextEngine prototype.")
+
+    assembled = engine.compress(original, current_tokens=_estimate_tokens(original))
+    joined = "\n".join(str(m.get("content", "")) for m in assembled)
+
+    assert _estimate_tokens(assembled) < _estimate_tokens(original) * 0.35
+    assert assembled[0] == original[0]
+    assert "source-backed engine target" in joined
+    assert "Available Ichor expansions" in joined
+    assert "raw_turns:session-1" in joined
+    assert "Fresh tail: PR #138 benchmark is ready." in joined
+    assert "Stale middle user turn 3" not in joined
+    assert engine.get_status()["last_pack_metrics"]["llm_calls"] == 0
+    assert engine.get_status()["last_pack_metrics"]["api_calls"] == 0
+
+
+def test_ichor_context_engine_unavailable_when_pack_builder_missing(monkeypatch) -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    monkeypatch.setattr(module, "build_context_pack", None)
+    monkeypatch.setattr(module, "_needs_memory_context", None)
+    engine = module.IchorContextEngine(fresh_tail_turns=4, max_pack_tokens=220)
+    engine.on_session_start("session-missing-pack")
+
+    assert engine.is_available() is False
+    assembled = engine.compress(_long_messages("Build Ichor context engine."))
+    joined = "\n".join(str(m.get("content", "")) for m in assembled)
+    assert "status=\"unavailable\"" not in joined
+    assert engine.get_status()["last_pack_metrics"]["db_reads"] == 0
+
+
+def test_ichor_context_engine_noop_turn_injects_no_pack_and_reads_nothing(monkeypatch) -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    engine = module.IchorContextEngine(fresh_tail_turns=4, max_pack_tokens=220)
+    engine.on_session_start("session-noop")
+
+    def forbidden_pack(**_kwargs):
+        raise AssertionError("no-op turn should not read/build Ichor context")
+
+    monkeypatch.setattr(engine, "_build_context_pack", forbidden_pack)
+    original = _long_messages("ok")
+
+    assembled = engine.compress(original, current_tokens=_estimate_tokens(original))
+    joined = "\n".join(str(m.get("content", "")) for m in assembled)
+
+    assert "<ichor-context" not in joined
+    assert "Available Ichor expansions" in joined
+    assert engine.get_status()["last_pack_metrics"] == {
+        "llm_calls": 0,
+        "api_calls": 0,
+        "db_reads": 0,
+        "db_writes": 0,
+        "tokens_estimated": 0,
+    }
+
+
+def test_ichor_context_engine_tools_expand_stored_raw_turns() -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    engine = module.IchorContextEngine(fresh_tail_turns=2)
+    engine.on_session_start("session-tools")
+    messages = _long_messages("Compare PR #138 tokens per turn.")
+    engine.compress(messages, current_tokens=_estimate_tokens(messages))
+
+    schemas = {schema["name"] for schema in engine.get_tool_schemas()}
+    assert {"ichor_status", "ichor_expand"}.issubset(schemas)
+
+    result = json.loads(engine.handle_tool_call(
+        "ichor_expand",
+        {"source_id": "raw_turns:session-tools:seq:1-3"},
+    ))
+    assert result["ok"] is True
+    assert "Original project goal" in result["content"]
+
+
+def test_ichor_expand_caps_large_raw_turn_output() -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    engine = module.IchorContextEngine(fresh_tail_turns=2, max_expand_chars=1200)
+    engine.on_session_start("session-cap")
+    messages = _long_messages("Compare PR #138 tokens per turn.")
+    engine.compress(messages, current_tokens=_estimate_tokens(messages))
+
+    result = json.loads(engine.handle_tool_call(
+        "ichor_expand",
+        {"source_id": "raw_turns:session-cap:seq:1-40"},
+    ))
+    assert result["ok"] is True
+    assert result["truncated"] is True
+    assert result["omitted_chars"] > 0
+    assert len(result["content"]) <= 1200
+
+
+def test_ichor_context_engine_persists_raw_turns_when_store_configured(tmp_path: Path) -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    from lib.ichor.raw_turns import RawTurnStore
+
+    store = RawTurnStore(tmp_path / "ichor.db")
+    engine = module.IchorContextEngine(fresh_tail_turns=2, raw_turn_store=store)
+    engine.on_session_start("session-persisted")
+    messages = _long_messages("Persist these turns exactly.")
+
+    engine.compress(messages, current_tokens=_estimate_tokens(messages))
+    status = engine.get_status()
+
+    assert status["raw_turn_store"]["configured"] is True
+    assert status["raw_turn_store"]["last_result"]["inserted"] == len(messages)
+    assert status["raw_turn_store"]["frontier"]["last_ingested_seq"] == len(messages) - 1
+    persisted = store.fetch_range("session-persisted", 1, 3)
+    assert persisted[0].content == "Original project goal: reduce context tokens."
+
+
+def test_ichor_context_engine_expands_from_persisted_store_after_memory_loss(tmp_path: Path) -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    from lib.ichor.raw_turns import RawTurnStore
+
+    store = RawTurnStore(tmp_path / "ichor.db")
+    engine = module.IchorContextEngine(fresh_tail_turns=2, raw_turn_store=store)
+    engine.on_session_start("session-store-expand")
+    messages = _long_messages("Persist then expand from store.")
+    engine.compress(messages, current_tokens=_estimate_tokens(messages))
+    engine._raw_turns_by_session.clear()
+
+    result = json.loads(engine.handle_tool_call(
+        "ichor_expand",
+        {"source_id": "raw_turns:session-store-expand:seq:1-3"},
+    ))
+
+    assert result["ok"] is True
+    assert result["source"] == "persistent_store"
+    assert "Original project goal" in result["content"]
+
+
+def test_ichor_context_engine_default_has_no_persistent_store() -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+    engine = module.IchorContextEngine(fresh_tail_turns=2)
+    engine.on_session_start("session-default-no-store")
+    messages = _long_messages("No live DB mutation by default.")
+
+    engine.compress(messages, current_tokens=_estimate_tokens(messages))
+
+    assert engine.get_status()["raw_turn_store"] == {"configured": False}
+
+
+def test_ichor_context_engine_persistent_store_failure_is_prompt_quiet() -> None:
+    module = importlib.import_module("plugins.context_engine.ichor")
+
+    class BrokenStore:
+        def ingest_messages(self, *_args, **_kwargs):
+            raise sqlite3.OperationalError("read only")
+
+        def get_frontier(self, _session_id):
+            raise sqlite3.OperationalError("read only")
+
+    engine = module.IchorContextEngine(fresh_tail_turns=2, raw_turn_store=BrokenStore())
+    engine.on_session_start("session-broken-store")
+    messages = _long_messages("ok")
+
+    assembled = engine.compress(messages, current_tokens=_estimate_tokens(messages))
+    joined = "\n".join(str(m.get("content", "")) for m in assembled)
+    status = engine.get_status()["raw_turn_store"]
+
+    assert "read only" not in joined
+    assert status["configured"] is True
+    assert status["last_result"] is None
+    assert status["last_error"] == "OperationalError"
+    result = json.loads(engine.handle_tool_call(
+        "ichor_expand",
+        {"source_id": "raw_turns:session-broken-store:seq:1-3"},
+    ))
+    assert result["ok"] is True
+    assert result["source"] == "in_memory"

--- a/tests/test_ichor_context_engine_turn_benchmark.py
+++ b/tests/test_ichor_context_engine_turn_benchmark.py
@@ -1,0 +1,65 @@
+"""Tests for IchorContextEngine per-turn token economy benchmark.
+
+These tests lock Thoth's course-correction marker into executable gates:
+benchmark the default-off IchorContextEngine on tokens sent per turn, not only
+post-threshold compression size. The benchmark must remain offline and must not
+flip profile/fleet defaults.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "benchmark-ichor-context-engine-turns.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("benchmark_ichor_context_engine_turns", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_turn_benchmark_shows_ichor_sends_fewer_tokens_per_turn(tmp_path: Path) -> None:
+    module = load_module()
+    payload = module.run_benchmark(tmp_path)
+    summary = payload["summary"]
+
+    assert payload["mode"] == "ichor_context_engine_turn_benchmark"
+    assert summary["rows_run"] >= 3
+    assert summary["benchmark_ready"] is True
+    assert summary["baseline_label"] == "full transcript resend baseline until compressor threshold"
+    assert summary["token_estimate_method"] == "len_div_4_heuristic"
+    assert summary["ichor_total_tokens"] < summary["default_total_tokens"]
+    assert summary["ichor_avg_tokens_per_turn"] < summary["default_avg_tokens_per_turn"]
+    assert summary["all_ichor_no_llm_api"] is True
+    assert summary["all_noop_rows_clean"] is True
+    assert summary["all_rows_have_expand_handles"] is True
+    assert summary["blockers"] == []
+
+
+def test_turn_benchmark_cli_writes_private_artifacts(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "turn-benchmark"
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--artifact-dir", str(artifact_dir), "--format", "json"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = json.loads(proc.stdout)
+    summary = payload["summary"]
+
+    assert payload["mode"] == "ichor_context_engine_turn_benchmark"
+    assert summary["benchmark_ready"] is True
+    assert summary["token_estimate_method"] == "len_div_4_heuristic"
+    assert Path(payload["summary_path"]).exists()
+    assert Path(payload["report_path"]).exists()
+    assert artifact_dir.stat().st_mode & 0o777 == 0o700

--- a/tests/test_ichor_context_engine_turn_benchmark.py
+++ b/tests/test_ichor_context_engine_turn_benchmark.py
@@ -33,7 +33,9 @@ def test_turn_benchmark_shows_ichor_sends_fewer_tokens_per_turn(tmp_path: Path) 
     summary = payload["summary"]
 
     assert payload["mode"] == "ichor_context_engine_turn_benchmark"
-    assert summary["rows_run"] >= 3
+    assert summary["rows_run"] >= 4
+    assert summary["default_compressor_exercised_rows"] >= 1
+    assert "long-threshold-compressor-pressure" in summary["threshold_crossing_case_ids"]
     assert summary["benchmark_ready"] is True
     assert summary["baseline_label"] == "full transcript resend baseline until compressor threshold"
     assert summary["token_estimate_method"] == "len_div_4_heuristic"
@@ -59,6 +61,7 @@ def test_turn_benchmark_cli_writes_private_artifacts(tmp_path: Path) -> None:
 
     assert payload["mode"] == "ichor_context_engine_turn_benchmark"
     assert summary["benchmark_ready"] is True
+    assert summary["default_compressor_exercised_rows"] >= 1
     assert summary["token_estimate_method"] == "len_div_4_heuristic"
     assert Path(payload["summary_path"]).exists()
     assert Path(payload["report_path"]).exists()

--- a/tests/test_ichor_context_pack.py
+++ b/tests/test_ichor_context_pack.py
@@ -1,0 +1,547 @@
+"""
+Ichor-Retrieval Phase 0 baseline + Phase 1 context-pack contract tests.
+
+Spec: ~/pantheon/plans/ichor-athenaeum-god-aware-retrieval-build-spec-v1.md
+      §Phase 0 (baseline) + Phase 1 (build_context_pack)
+
+This file consumes the golden-queries fixture at
+    tests/fixtures/ichor_golden_queries.yaml
+
+and asserts the Phase 1 contract: a god-aware context pack whose
+shape is determined by the (god, phase) tuple.
+
+Phase 0 baseline:
+
+  * The golden-query fixture is readable and distinguishes god-specific
+    expectations before implementation work begins.
+
+Phase 1 contract:
+
+  * `build_context_pack(query, god_name, phase, task_type, max_items)`
+    returns a dict with the spec's required keys.
+  * The golden queries distinguish Hephaestus and Thoth expectations
+    for the SAME query text.
+  * Every claim has source evidence/path/id.
+  * No unhydrated vector-only item appears as a primary context item.
+
+Acceptance criterion from the build spec §Phase 0:
+  > Golden-query fixture distinguishes Hephaestus and Thoth
+  > expectations for same query.
+
+That's `TestContract.test_golden_query_distinguishes_hephaestus_and_thoth`.
+
+No service restart required.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+GOLDEN_QUERIES_PATH = Path(_ROOT) / "tests" / "fixtures" / "ichor_golden_queries.yaml"
+DRY_RUN_SCRIPT_PATH = Path(_ROOT) / "scripts" / "dry-run-ichor-context-pack.py"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Fixture loader
+# ─────────────────────────────────────────────────────────────────────
+
+def _load_golden_queries() -> List[Dict[str, Any]]:
+    """Load the golden-queries fixture.
+
+    Returns the list of query dicts (the `queries:` block).
+    Raises a clear assertion error if the file is missing or
+    malformed — both block Phase 0 closure.
+    """
+    assert GOLDEN_QUERIES_PATH.exists(), (
+        f"Golden-queries fixture missing: {GOLDEN_QUERIES_PATH}"
+    )
+    with open(GOLDEN_QUERIES_PATH, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    assert isinstance(data, dict), f"top-level must be a mapping, got {type(data)}"
+    assert "queries" in data, "missing 'queries:' block"
+    queries = data["queries"]
+    assert isinstance(queries, list) and len(queries) > 0, (
+        "'queries' must be a non-empty list"
+    )
+    for q in queries:
+        for required in ("id", "query", "god", "phase", "must_include"):
+            assert required in q, f"golden query {q.get('id', '?')} missing {required!r}"
+    return queries
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────
+
+def _candidate_import_paths() -> List[str]:
+    """Module paths Phase 9 might land `ichor_context_pack` under.
+
+    We probe each one and report which exists / which doesn't. The
+    baseline test asserts NONE of them resolves today.
+    """
+    return [
+        "lib.ichor.context_pack",
+        "lib.ichor.context_pack.build_context_pack",
+        "lib.ichor.context_pack.ichor_context_pack",
+    ]
+
+
+def _has_context_pack_callable() -> bool:
+    """Return True iff `ichor_context_pack` is importable as a callable.
+
+    Probes a few candidate module paths. The probe is best-effort
+    and never raises.
+    """
+    for path in _candidate_import_paths():
+        try:
+            mod = importlib.import_module(path)
+        except (ImportError, ModuleNotFoundError):
+            continue
+        attr = getattr(mod, "ichor_context_pack", None) or getattr(
+            mod, "build_context_pack", None
+        )
+        if callable(attr):
+            return True
+    return False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# BASELINE: fixture and dry-run safety guards
+# ─────────────────────────────────────────────────────────────────────
+
+class TestBaseline(unittest.TestCase):
+    """Phase 0 baseline fixture guards that remain valid in Phase 1."""
+
+    def test_golden_queries_fixture_loads(self) -> None:
+        """The golden-queries fixture is readable and well-formed.
+
+        This guards the fixture itself. If a future edit breaks the
+        YAML, this test catches it before downstream tests do.
+        """
+        queries = _load_golden_queries()
+        self.assertGreaterEqual(len(queries), 3,
+            "spec requires 3 golden queries; fixture has fewer")
+
+    def test_golden_queries_have_distinct_expectations(self) -> None:
+        """The same query for different gods must have different must_include sets.
+
+        This is the §Phase 0 acceptance criterion:
+          > Golden-query fixture distinguishes Hephaestus and Thoth
+          > expectations for same query.
+        """
+        queries = _load_golden_queries()
+        by_query: Dict[str, List[Dict[str, Any]]] = {}
+        for q in queries:
+            by_query.setdefault(q["query"], []).append(q)
+
+        # Find a query that appears multiple times
+        same_query = [
+            (qtext, qs) for qtext, qs in by_query.items() if len(qs) > 1
+        ]
+        self.assertTrue(
+            same_query,
+            "fixture should have at least one query used by multiple gods "
+            "(the spec example: 'Conductor v2' for hephaestus + thoth)",
+        )
+        # For each repeated query, the must_include sets must differ
+        for qtext, qs in same_query:
+            include_sets = [tuple(sorted(q["must_include"])) for q in qs]
+            self.assertGreater(
+                len(set(include_sets)), 1,
+                f"query {qtext!r} has identical must_include across gods; "
+                "golden-queries fixture does NOT distinguish expectations",
+            )
+
+    def test_golden_queries_have_required_gods(self) -> None:
+        """The three required gods are present."""
+        queries = _load_golden_queries()
+        gods = {q["god"] for q in queries}
+        for required in ("hephaestus", "thoth", "rheta"):
+            self.assertIn(
+                required, gods,
+                f"golden-queries fixture missing required god {required!r}",
+            )
+
+    def test_golden_query_must_include_tokens_are_substrings(self) -> None:
+        """Tokens in must_include are short enough to be useful substrings.
+
+        Guard rail: prevents a future edit that adds a 200-char
+        string to must_include, which would make the assertion
+        useless.
+        """
+        queries = _load_golden_queries()
+        for q in queries:
+            for token in q["must_include"]:
+                self.assertLessEqual(
+                    len(token), 40,
+                    f"query {q['id']}!r: must_include token {token!r} is "
+                    "too long to be a useful substring match",
+                )
+                self.assertGreater(
+                    len(token), 0,
+                    f"query {q['id']}!r: empty must_include token",
+                )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# PHASE 0 DRY-RUN: measurement scaffold, no context-pack behavior
+# ─────────────────────────────────────────────────────────────────────
+
+class TestPhase0DryRunCLI(unittest.TestCase):
+    """Phase 0 dry-run measurement harness."""
+
+    def _run_json(self, *extra_args: str) -> Dict[str, Any]:
+        env = os.environ.copy()
+        env["PYTHONPATH"] = _ROOT
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(DRY_RUN_SCRIPT_PATH),
+                "--god",
+                "thoth",
+                "--phase",
+                "research",
+                "--query",
+                "Conductor v2",
+                "--max-items",
+                "8",
+                "--format",
+                "json",
+                *extra_args,
+            ],
+            cwd=_ROOT,
+            env=env,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        return json.loads(proc.stdout)
+
+    def test_dry_run_json_emits_runtime_safety_fields(self) -> None:
+        payload = self._run_json()
+        for key in (
+            "would_mutate_runtime",
+            "would_rotate_session",
+            "would_rewrite_transcript",
+            "would_change_config",
+            "would_restart_gateway",
+        ):
+            self.assertIn(key, payload)
+            self.assertIs(payload[key], False)
+
+    def test_dry_run_json_emits_metric_schema_without_llm_or_writes(self) -> None:
+        payload = self._run_json("--compare-default-compressor")
+        metrics = payload["metrics"]
+        for key in (
+            "wall_ms",
+            "rss_delta_kb",
+            "peak_rss_kb",
+            "db_reads",
+            "db_writes",
+            "rows_examined",
+            "tokens_estimated",
+            "llm_calls",
+            "api_calls",
+            "cache_read_tokens",
+            "cache_write_tokens",
+        ):
+            self.assertIn(key, metrics)
+        self.assertEqual(metrics["llm_calls"], 0)
+        self.assertEqual(metrics["api_calls"], 0)
+        self.assertEqual(metrics["db_writes"], 0)
+        self.assertIn("candidate_context_pack", payload)
+        candidate = payload["candidate_context_pack"]
+        self.assertIn("injectable_context", candidate)
+        self.assertEqual(candidate["metrics"]["llm_calls"], 0)
+        self.assertEqual(candidate["metrics"]["api_calls"], 0)
+        self.assertEqual(candidate["metrics"]["db_writes"], 0)
+        self.assertIn("default_compressor_baseline", payload)
+        self.assertNotIn("compressed_messages", payload["default_compressor_baseline"])
+        self.assertIs(payload["default_compressor_baseline"]["would_call_compress_method"], False)
+        self.assertEqual(payload["default_compressor_baseline"]["api_calls"], 0)
+
+    def test_dry_run_script_avoids_forbidden_runtime_mutation_paths(self) -> None:
+        script = DRY_RUN_SCRIPT_PATH.read_text(encoding="utf-8")
+        for forbidden in (
+            "_compress_context",
+            ".compress(",
+            "SessionDB",
+            ".end_session(",
+            "continuation session",
+            "config.yaml",
+            "systemctl",
+            "hermes-gateway",
+        ):
+            self.assertNotIn(forbidden, script)
+
+    def test_dry_run_markdown_reports_non_mutation(self) -> None:
+        env = os.environ.copy()
+        env["PYTHONPATH"] = _ROOT
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(DRY_RUN_SCRIPT_PATH),
+                "--god",
+                "thoth",
+                "--phase",
+                "research",
+                "--query",
+                "Conductor v2",
+                "--max-items",
+                "8",
+                "--compare-default-compressor",
+                "--format",
+                "markdown",
+            ],
+            cwd=_ROOT,
+            env=env,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        self.assertIn("would_mutate_runtime: false", proc.stdout)
+        self.assertIn("llm_calls: 0", proc.stdout)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# CONTRACT: Phase 1 deliverables
+# ─────────────────────────────────────────────────────────────────────
+
+class TestContract:
+    """Phase 1 contract — god-aware context pack."""
+
+    def test_ichor_context_pack_is_callable(self) -> None:
+        assert _has_context_pack_callable(), (
+            "Phase 1 must ship ichor_context_pack (or build_context_pack) "
+            "at one of: " + ", ".join(_candidate_import_paths())
+        )
+
+    def test_context_pack_return_shape(self) -> None:
+        """Phase 1 must return the spec's required shape."""
+        from lib.ichor.context_pack import build_context_pack  # type: ignore
+        pack = build_context_pack(
+            "Conductor v2", god_name="hephaestus", phase="debug",
+            max_items=8,
+        )
+        required_keys = {
+            "query", "god", "phase",
+            "injectable_context",
+            "coverage",
+            "current_decisions", "hard_constraints", "relevant_files",
+            "risks", "related_entities", "recent_changes",
+            "source_links", "omitted", "metrics",
+        }
+        for key in required_keys:
+            assert key in pack, f"context_pack missing required key: {key!r}"
+        assert pack["god"] == "hephaestus"
+        assert pack["phase"] == "debug"
+        assert isinstance(pack["omitted"], dict)
+        assert "count" in pack["omitted"]
+        assert "reasons" in pack["omitted"]
+        assert isinstance(pack["injectable_context"], str)
+        assert pack["injectable_context"]
+        assert pack["metrics"]["llm_calls"] == 0
+        assert pack["metrics"]["api_calls"] == 0
+        assert pack["metrics"]["db_writes"] == 0
+
+    def test_context_pack_noop_path_has_no_db_or_prompt_growth(self) -> None:
+        """Casual turns should stay a zero-read/no-injection fast path."""
+        from lib.ichor.context_pack import build_context_pack  # type: ignore
+
+        for god in ("hermes", "thoth", "hephaestus"):
+            pack = build_context_pack(
+                "random casual hello", god_name=god, phase="chat", max_items=8,
+            )
+
+            assert pack["coverage"]["status"] == "low"
+            assert pack["coverage"]["returned"] == 0
+            assert pack["injectable_context"] == ""
+            assert pack["metrics"]["db_reads"] == 0
+            assert pack["metrics"]["db_writes"] == 0
+            assert pack["metrics"]["llm_calls"] == 0
+            assert pack["metrics"]["api_calls"] == 0
+            assert "classifier_no_memory_need" in pack["omitted"]["reasons"]
+
+    def test_db_candidate_titles_are_clean_human_labels(self) -> None:
+        """DB-backed source titles should not expose markdown/table fragments."""
+        from lib.ichor.context_pack import _db_item  # type: ignore
+
+        bad_titles = [
+            'engineering/debug context, while: ```text ichor_context_pack("Conductor',
+            "args: 'ok', description='LCM status",
+            "On, every God profile https://example.invalid/path",
+            "clear **build sequence** for Conductor",
+            "For the Ichor-backed context idea,",
+            "Use `context_pack` helper",
+            "Example www.example.com",
+            "Example HTTPS://example.invalid",
+            "Example WWW.example.com",
+            "Example WWW portal",
+            "Clean title\nwith table-ish fragment",
+            "Conductor #setup",
+            f"Title{'x' * 190} https://example.invalid",
+        ]
+
+        for title in bad_titles:
+            item = _db_item(
+                source="ichor_claims",
+                source_id="ichor_claims:123",
+                title=title,
+                text="A useful source-backed Ichor context claim.",
+                source_path="session-123",
+            )
+
+            assert item is not None
+            assert item["title"] == "Ichor claims 123"
+            assert "```" not in item["title"]
+            assert "|" not in item["title"]
+            assert "http" not in item["title"].lower()
+            assert "**" not in item["title"]
+
+    def test_golden_query_distinguishes_hephaestus_and_thoth(self) -> None:
+        """For 'Conductor v2', hephaestus sees NATS/MCP/endpoint/systemd
+        and thoth sees workflow/cross-god/routing. The same query text
+        must produce role-differentiated packs.
+        """
+        from lib.ichor.context_pack import build_context_pack  # type: ignore
+
+        hep_pack = build_context_pack(
+            "Conductor v2", god_name="hephaestus", phase="debug", max_items=8,
+        )
+        thoth_pack = build_context_pack(
+            "Conductor v2", god_name="thoth", phase="research", max_items=8,
+        )
+
+        # Serialize both packs to text so substring assertions work
+        def _pack_text(p: Dict[str, Any]) -> str:
+            parts = [p.get("query", "")]
+            for k in (
+                "current_decisions", "hard_constraints", "relevant_files",
+                "risks", "related_entities", "recent_changes",
+            ):
+                for v in p.get(k, []) or []:
+                    if isinstance(v, dict):
+                        for vv in v.values():
+                            parts.append(str(vv))
+                    else:
+                        parts.append(str(v))
+            return " \n ".join(parts).lower()
+
+        hep_text = _pack_text(hep_pack)
+        thoth_text = _pack_text(thoth_pack)
+
+        for token in ("NATS", "MCP", "endpoint", "systemd"):
+            assert token.lower() in hep_text, (
+                f"Hephaestus debug pack missing must_include token {token!r}"
+            )
+        for token in ("workflow", "cross-god", "routing"):
+            assert token.lower() in thoth_text, (
+                f"Thoth research pack missing must_include token {token!r}"
+            )
+
+        # Distinction: the two packs must NOT be byte-identical
+        assert hep_text != thoth_text, (
+            "Hephaestus and Thoth packs for 'Conductor v2' are identical; "
+            "the context pack is not role-aware"
+        )
+
+    def test_context_pack_has_source_evidence_per_claim(self) -> None:
+        """Every primary claim has a source path/id (no unhydrated vectors)."""
+        from lib.ichor.context_pack import build_context_pack  # type: ignore
+        pack = build_context_pack(
+            "Conductor v2", god_name="hephaestus", phase="debug", max_items=8,
+        )
+        for key in (
+            "current_decisions", "hard_constraints", "relevant_files",
+            "risks", "related_entities", "recent_changes",
+        ):
+            for claim in pack.get(key, []) or []:
+                if isinstance(claim, dict):
+                    has_source = any(
+                        k in claim for k in ("source", "source_path", "source_id", "path", "id")
+                    )
+                    assert has_source, (
+                        f"context_pack[{key}] claim lacks source evidence: {claim!r}"
+                    )
+
+    def test_rheta_pricing_golden_query(self) -> None:
+        """The third golden query: Rheta writing pricing copy."""
+        from lib.ichor.context_pack import build_context_pack  # type: ignore
+        pack = build_context_pack(
+            "Pantheon pricing managed retainer dedicated infrastructure",
+            god_name="rheta", phase="copywriting", max_items=8,
+        )
+        pack_text = " ".join(
+            str(v) for k in pack
+            if k not in ("omitted", "coverage")
+            for v in (pack[k] if isinstance(pack[k], list) else [pack[k]])
+        ).lower()
+        for token in ("$5k", "managed", "dedicated infrastructure"):
+            assert token.lower() in pack_text, (
+                f"Rheta copywriting pack missing must_include token {token!r}"
+            )
+
+    def test_context_pack_recalls_own_dry_run_design_for_followup_query(self) -> None:
+        """A real operator follow-up should retrieve the context-pack design itself.
+
+        This guards the intended effect beyond canned Conductor examples:
+        asking where the Ichor context-pack work stands should return a
+        source-backed pack with the dry-run/manual/no-LCM safety decision.
+        """
+        from lib.ichor.context_pack import build_context_pack  # type: ignore
+
+        pack = build_context_pack(
+            "where did we leave the Ichor context pack?",
+            god_name="hermes",
+            phase="ops",
+            max_items=8,
+            dry_run=True,
+        )
+        pack_text = pack["injectable_context"].lower()
+        source_paths = "\n".join(link["source_path"] for link in pack["source_links"])
+
+        assert pack["coverage"]["status"] == "ok"
+        assert pack["coverage"]["returned"] >= 2
+        assert "dry-run" in pack_text or "dry_run" in pack_text
+        assert "manual" in pack_text
+        assert "lcm" in pack_text
+        assert "ichor-context-pack-compressor-augmentation" in source_paths
+        assert pack["metrics"]["llm_calls"] == 0
+        assert pack["metrics"]["api_calls"] == 0
+        assert pack["metrics"]["db_writes"] == 0
+        assert pack["metrics"]["tokens_estimated"] <= 900
+
+    def test_context_pack_operator_query_stays_bounded_without_runtime_mutation(self) -> None:
+        """Follow-up recall can improve without becoming a live compression path."""
+        from lib.ichor.context_pack import build_context_pack  # type: ignore
+
+        pack = build_context_pack(
+            "should we enable the Ichor context pack canary now?",
+            god_name="hermes",
+            phase="ops",
+            max_items=8,
+            max_tokens=900,
+            max_ms=350,
+            dry_run=True,
+        )
+
+        assert pack["coverage"]["returned"] > 0
+        assert pack["metrics"]["mode"] == "dry_run"
+        assert pack["metrics"]["llm_calls"] == 0
+        assert pack["metrics"]["api_calls"] == 0
+        assert pack["metrics"]["db_writes"] == 0
+        assert pack["metrics"]["tokens_estimated"] <= 900
+        assert pack["metrics"]["wall_ms"] <= 350

--- a/tests/test_ichor_context_pack_canary.py
+++ b/tests/test_ichor_context_pack_canary.py
@@ -1,0 +1,128 @@
+"""Canary readiness replay harness tests for Ichor context packs.
+
+These tests guard the next step after the dry-run surface: a replay-only
+canary readiness harness that produces artifacts and a yes/no gate without
+wiring any live profile or gateway path.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+CANARY_SCRIPT = _ROOT / "scripts" / "replay-ichor-context-pack-canary.py"
+CANARY_DOC = _ROOT / "docs" / "ichor-context-pack-canary.md"
+
+
+def _run_harness(artifact_dir: Path) -> dict:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(_ROOT)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(CANARY_SCRIPT),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--format",
+            "json",
+        ],
+        cwd=_ROOT,
+        env=env,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def test_canary_harness_writes_replay_artifacts_without_live_mutation(tmp_path: Path) -> None:
+    """The harness should write a report, not mutate runtime/live state."""
+    payload = _run_harness(tmp_path / "artifacts")
+    summary = payload["summary"]
+
+    assert payload["mode"] == "dry_run_replay"
+    assert summary["rows_run"] >= 8
+    assert summary["safety_pass"] is True
+    assert summary["all_no_llm_api"] is True
+    assert summary["all_no_db_writes"] is True
+    assert summary["all_safety_flags_false"] is True
+    assert summary["noop_rows_clean"] is True
+    assert payload["would_change_config"] is False
+    assert payload["would_restart_gateway"] is False
+    assert payload["would_mutate_runtime"] is False
+    assert payload["would_rotate_session"] is False
+    assert payload["would_rewrite_transcript"] is False
+
+    artifact_dir = Path(payload["artifact_dir"])
+    assert artifact_dir.exists()
+    assert Path(payload["summary_path"]).exists()
+    assert Path(payload["report_path"]).exists()
+    assert len(payload["case_paths"]) == summary["rows_run"]
+    for case_path in payload["case_paths"]:
+        assert Path(case_path).exists()
+
+
+def test_canary_harness_scores_quality_and_noop_rows(tmp_path: Path) -> None:
+    """Quality/readiness is scored separately from safety."""
+    payload = _run_harness(tmp_path / "artifacts")
+    summary = payload["summary"]
+
+    assert "quality_pass" in summary
+    assert "canary_ready" in summary
+    assert summary["operator_followup_rows_ok"] is True
+    assert summary["source_backed_rows_ok"] is True
+    assert summary["noop_rows_clean"] is True
+
+    noop_rows = [row for row in payload["rows"] if row["expected_zero"]]
+    assert noop_rows, "matrix must include casual/no-op rows"
+    for row in noop_rows:
+        assert row["coverage_status"] == "low"
+        assert row["returned"] == 0
+        assert row["db_reads"] == 0
+        assert row["tokens_estimated"] == 0
+        assert row["injectable_context_length"] == 0
+
+    operator_rows = [row for row in payload["rows"] if row["category"] == "operator_followup"]
+    assert operator_rows, "matrix must include operator follow-up rows"
+    for row in operator_rows:
+        assert row["coverage_status"] == "ok"
+        assert row["returned"] >= row["min_returned"]
+        assert row["source_link_count"] >= row["min_returned"]
+
+
+def test_canary_harness_static_boundary_has_no_live_escape_hatch() -> None:
+    """The harness must not expose live/canary mutation operations."""
+    script = CANARY_SCRIPT.read_text(encoding="utf-8")
+    forbidden = (
+        "dry_run=False",
+        "context.engine",
+        "compression.*",
+        "systemctl",
+        "hermes-gateway",
+        "SessionDB",
+        ".end_session(",
+        "_compress_context",
+        ".compress(",
+        'subprocess.run(["git',
+    )
+    for token in forbidden:
+        assert token not in script
+
+
+def test_canary_plan_doc_names_rollback_and_non_goals() -> None:
+    """The operator doc must preserve the dry-run/replay boundary."""
+    text = CANARY_DOC.read_text(encoding="utf-8").lower()
+    for token in (
+        "replay-only",
+        "no live profile",
+        "no gateway restart",
+        "no lcm",
+        "rollback",
+        "canary_ready",
+        "source grounding",
+    ):
+        assert token in text

--- a/tests/test_ichor_context_pack_rollout_simulation.py
+++ b/tests/test_ichor_context_pack_rollout_simulation.py
@@ -13,9 +13,15 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "simulate-ichor-context-pack-rollout.py"
+HAS_ROLLOUT_FIXTURE = (
+    (Path.home() / ".hermes" / "ichor.db").exists()
+    and Path("/home/konan/athenaeum").exists()
+)
 
 
 def load_module():
@@ -82,6 +88,10 @@ def test_noop_case_does_not_inject_or_read_memory(tmp_path: Path) -> None:
     assert row["tokens_estimated"] == 0
 
 
+@pytest.mark.skipif(
+    not HAS_ROLLOUT_FIXTURE,
+    reason="rollout simulation matrix requires local Ichor DB and Athenaeum anchors",
+)
 def test_cli_writes_rollout_simulation_artifacts_and_summary(tmp_path: Path) -> None:
     artifact_dir = tmp_path / "rollout-sim"
     proc = subprocess.run(

--- a/tests/test_ichor_context_pack_rollout_simulation.py
+++ b/tests/test_ichor_context_pack_rollout_simulation.py
@@ -1,0 +1,117 @@
+"""Controlled rollout simulation tests for Ichor context packs.
+
+The replay harness proves the builder is safe and source-backed. The next gate is
+slightly closer to rollout: compose a prompt-shaped message list that includes
+an Ichor context pack only when memory is actually needed, while still staying
+fully offline/read-only.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "simulate-ichor-context-pack-rollout.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("simulate_ichor_context_pack_rollout", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_positive_case_injects_source_backed_context_without_live_mutation(tmp_path: Path) -> None:
+    module = load_module()
+
+    row, artifact = module.simulate_case(
+        module.SimulationCase(
+            case_id="hermes-context-pack-followup",
+            god="hermes",
+            phase="ops",
+            query="where did we leave the Ichor context pack?",
+            expected_injection=True,
+            min_sources=2,
+        ),
+        tmp_path,
+    )
+
+    assert artifact.exists()
+    assert row["injected"] is True
+    assert row["source_link_count"] >= 2
+    assert row["prompt_message_count_after"] == row["prompt_message_count_before"] + 1
+    assert row["prompt_token_delta"] > 0
+    assert row["llm_calls"] == 0
+    assert row["api_calls"] == 0
+    assert row["db_writes"] == 0
+    assert row["would_mutate_runtime"] is False
+    assert row["would_change_config"] is False
+    assert row["would_restart_gateway"] is False
+    assert row["would_rotate_session"] is False
+    assert row["would_rewrite_transcript"] is False
+
+
+def test_noop_case_does_not_inject_or_read_memory(tmp_path: Path) -> None:
+    module = load_module()
+
+    row, artifact = module.simulate_case(
+        module.SimulationCase(
+            case_id="hermes-casual-noop",
+            god="hermes",
+            phase="chat",
+            query="random casual hello",
+            expected_injection=False,
+            min_sources=0,
+        ),
+        tmp_path,
+    )
+
+    assert artifact.exists()
+    assert row["injected"] is False
+    assert row["source_link_count"] == 0
+    assert row["prompt_message_count_after"] == row["prompt_message_count_before"]
+    assert row["prompt_token_delta"] == 0
+    assert row["db_reads"] == 0
+    assert row["tokens_estimated"] == 0
+
+
+def test_cli_writes_rollout_simulation_artifacts_and_summary(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "rollout-sim"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--format",
+            "json",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = json.loads(proc.stdout)
+    summary = payload["summary"]
+
+    assert payload["mode"] == "prompt_injection_simulation"
+    assert summary["rows_run"] >= 6
+    assert summary["safety_pass"] is True
+    assert summary["quality_pass"] is True
+    assert summary["rollout_sim_ready"] is True
+    assert summary["all_no_llm_api"] is True
+    assert summary["all_no_db_writes"] is True
+    assert summary["noop_rows_clean"] is True
+    assert payload["would_mutate_runtime"] is False
+    assert payload["would_change_config"] is False
+    assert payload["would_restart_gateway"] is False
+    assert Path(payload["summary_path"]).exists()
+    assert Path(payload["report_path"]).exists()
+    assert len(payload["case_paths"]) == summary["rows_run"]

--- a/tests/test_ichor_raw_turns.py
+++ b/tests/test_ichor_raw_turns.py
@@ -1,0 +1,75 @@
+"""Tests for lossless Ichor raw-turn persistence."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from lib.ichor.raw_turns import RawTurnStore
+
+
+def _messages() -> list[dict[str, object]]:
+    return [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "Build the Ichor raw turn store."},
+        {
+            "role": "assistant",
+            "content": "Working.",
+            "tool_calls": [{"id": "call_1", "function": {"name": "search_files"}}],
+        },
+        {"role": "tool", "content": "tool result payload", "tool_call_id": "call_1", "name": "search_files"},
+    ]
+
+
+def test_raw_turn_store_migrate_is_idempotent(tmp_path: Path) -> None:
+    store = RawTurnStore(tmp_path / "ichor.db")
+
+    first = store.migrate()
+    second = store.migrate()
+
+    assert first["tables_ready"] == ["ichor_raw_turns", "ichor_session_frontier"]
+    assert second["tables_ready"] == ["ichor_raw_turns", "ichor_session_frontier"]
+    with sqlite3.connect(tmp_path / "ichor.db") as conn:
+        indexes = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index'").fetchall()
+        }
+    assert "idx_ichor_raw_turns_hash" in indexes
+    assert "idx_ichor_raw_turns_created" in indexes
+
+
+def test_raw_turn_store_ingests_lossless_idempotent_messages(tmp_path: Path) -> None:
+    store = RawTurnStore(tmp_path / "ichor.db")
+    messages = _messages()
+
+    first = store.ingest_messages("session-a", messages)
+    second = store.ingest_messages("session-a", messages)
+
+    assert first == {"seen": 4, "inserted": 4, "updated": 0, "last_seq": 3}
+    assert second == {"seen": 4, "inserted": 0, "updated": 0, "last_seq": 3}
+    rows = store.fetch_range("session-a", 1, 3)
+    assert [row.seq for row in rows] == [1, 2, 3]
+    assert rows[0].content == "Build the Ichor raw turn store."
+    assert rows[1].tool_name == "search_files"
+    assert rows[2].tool_call_id == "call_1"
+    assert json.loads(rows[2].message_json)["content"] == "tool result payload"
+    assert len(rows[2].content_hash) == 64
+    assert store.get_frontier("session-a") == {
+        "session_id": "session-a",
+        "last_ingested_seq": 3,
+        "active_tail_start_seq": 0,
+    }
+
+
+def test_raw_turn_store_updates_changed_seq_without_duplication(tmp_path: Path) -> None:
+    store = RawTurnStore(tmp_path / "ichor.db")
+    messages = _messages()
+    store.ingest_messages("session-a", messages)
+    changed = list(messages)
+    changed[1] = {"role": "user", "content": "Changed exact text."}
+
+    result = store.ingest_messages("session-a", changed)
+
+    assert result == {"seen": 4, "inserted": 0, "updated": 1, "last_seq": 3}
+    rows = store.fetch_range("session-a", 1, 1)
+    assert rows[0].content == "Changed exact text."

--- a/tests/test_profile_bootstrap_apply_canary.py
+++ b/tests/test_profile_bootstrap_apply_canary.py
@@ -1,0 +1,91 @@
+"""Contract tests for disposable canary profile handling.
+
+The profile-bootstrap applier has two different audiences:
+
+* production/default bootstrap runs, which should only touch the real Pantheon
+  god fleet; and
+* explicitly scoped disposable canary runs, which may target ``ichor-canary``
+  while we validate the Ichor context-pack integration.
+
+A regression here is risky in both directions. Rejecting ``--god ichor-canary``
+breaks the live disposable canary path. Including ``ichor-canary`` in default
+runs silently promotes test infrastructure into the production bootstrap fleet.
+These tests pin the intended boundary: explicit canary allowed, default canary
+excluded.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "conductor" / "scripts" / "profile-bootstrap-apply.py"
+
+
+def load_module():
+    """Load the hyphenated script filename as a Python module for direct tests."""
+    spec = importlib.util.spec_from_file_location("profile_bootstrap_apply", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_skill(root: Path) -> None:
+    """Create one canonical skill so dry-run output has deterministic rows."""
+    skill = root / "devops" / "example-skill" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("---\nname: example-skill\n---\n\n# Example\n", encoding="utf-8")
+
+
+def write_no_canon(path: Path) -> None:
+    """Create the required no-canon report with no filtered profile/skill tuples."""
+    path.write_text("# empty no-canon report for test\n", encoding="utf-8")
+
+
+def test_explicit_ichor_canary_profile_is_allowed_in_dry_run(tmp_path, capsys):
+    module = load_module()
+    canonical_root = tmp_path / "canonical"
+    profiles_root = tmp_path / "profiles"
+    no_canon = tmp_path / "no-canon.txt"
+    write_skill(canonical_root)
+    write_no_canon(no_canon)
+
+    rc = module.main([
+        "--god", "ichor-canary",
+        "--canonical-root", str(canonical_root),
+        "--profiles-root", str(profiles_root),
+        "--no-canon-report", str(no_canon),
+        "--json",
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    payload = json.loads(captured.out)
+    assert payload["results"]
+    assert {row["god"] for row in payload["results"]} == {"ichor-canary"}
+
+
+def test_default_profile_bootstrap_excludes_disposable_canary(tmp_path, capsys):
+    module = load_module()
+    canonical_root = tmp_path / "canonical"
+    profiles_root = tmp_path / "profiles"
+    no_canon = tmp_path / "no-canon.txt"
+    write_skill(canonical_root)
+    write_no_canon(no_canon)
+
+    rc = module.main([
+        "--canonical-root", str(canonical_root),
+        "--profiles-root", str(profiles_root),
+        "--no-canon-report", str(no_canon),
+        "--json",
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    payload = json.loads(captured.out)
+    gods = {row["god"] for row in payload["results"]}
+    assert "ichor-canary" not in gods
+    assert gods == set(module.TARGET_PROFILES)


### PR DESCRIPTION
## Summary
- Ports the verified Ichor context-pack / canary / rollout benchmark chain onto current `main` without converting the `hermes-agent` submodule into a normal directory.
- Adds the missing golden-query fixture to the main integration branch.
- Updates benchmark fake compressor hooks for the current Hermes `ContextCompressor._generate_summary(..., memory_context=...)` signature.
- Adds the long transcript threshold-pressure case to `benchmark-ichor-context-engine-turns.py` so the default compressor actually fires during the comparison.

## Verification
- `PYTHONPATH=/home/konan/.hermes/hermes-agent:/tmp/pantheon-ichor-main-integration /home/konan/.hermes/hermes-agent/.venv/bin/python -m pytest tests/test_ichor_context_pack.py tests/test_ichor_context_pack_canary.py tests/test_ichor_context_pack_rollout_simulation.py tests/test_ichor_compressor_weight_benchmark.py tests/test_ichor_context_engine.py tests/test_ichor_context_engine_turn_benchmark.py tests/test_ichor_raw_turns.py -q` → `43 passed in 2.70s`
- Hermes source wiring smoke: `PYTHONPATH=/home/konan/.hermes/hermes-agent:/tmp/pantheon-ichor-main-integration /home/konan/.hermes/hermes-agent/.venv/bin/python -m pytest tests/agent/test_ichor_context_engine_wiring.py -q` → `2 passed in 0.34s`
- `git diff --check` clean
- AST parse clean for changed Python files
- Long-threshold artifact: `/tmp/ichor-context-engine-long-threshold-20260814T171920Z/summary.json`

## Long-threshold benchmark result
```json
{"benchmark_ready": true, "default_compressor_exercised_rows": 1, "threshold_crossing_case_ids": ["long-threshold-compressor-pressure"], "default_total_tokens": 704895, "ichor_total_tokens": 466200, "tokens_saved": 238695, "tokens_saved_ratio": 0.3386, "all_ichor_no_llm_api": true, "all_noop_rows_clean": true, "all_rows_have_expand_handles": true, "all_no_runtime_mutation": true, "blockers": []}
```

## Runtime install note
This PR intentionally avoids modifying the `hermes-agent` submodule tree on `main`. The prior ops branch carried direct edits under `hermes-agent/`, but current `main` pins that path as a submodule. The Hermes runtime plugin/wiring was tested in `/home/konan/.hermes/hermes-agent`; deploying it into `/usr/local/lib/hermes-agent` is currently blocked by root-owned installed subdirectories (`/usr/local/lib/hermes-agent/agent` and `/usr/local/lib/hermes-agent/plugins` are `root:root 755`).

No fleet/default profile flip, no LCM enablement, and no live service restart were performed.
